### PR TITLE
Add more set accumulation operations

### DIFF
--- a/microcosm_eventsource/accumulation.py
+++ b/microcosm_eventsource/accumulation.py
@@ -35,12 +35,45 @@ def alias(other_event_type):
     return lambda state, event_type: [as_enum(other_event_type, event_type)]
 
 
-def difference(other_event_type):
+def addition(*other_event_types):
     """
-    Remove one event type
+    Add event types
 
     """
-    return lambda state, event_type: sorted(state - {as_enum(other_event_type, event_type), })
+    def _addition(state, event_type):
+        to_add = {
+            as_enum(other_event_type, event_type)
+            for other_event_type in other_event_types
+        }
+        return sorted(state | to_add)
+    return _addition
+
+
+def difference(*other_event_types):
+    """
+    Remove event types
+
+    """
+    def _difference(state, event_type):
+        to_add = {
+            as_enum(other_event_type, event_type)
+            for other_event_type in other_event_types
+        }
+        return sorted(state - to_add)
+    return _difference
+
+
+def compose(*funcs):
+    """
+    Compose multiple accumulations.
+
+    """
+    def _compose(state, event_type):
+        new_state = state
+        for func in funcs:
+            new_state = func(set(new_state), event_type)
+        return new_state
+    return _compose
 
 
 def union():

--- a/microcosm_eventsource/tests/test_accumulation.py
+++ b/microcosm_eventsource/tests/test_accumulation.py
@@ -5,7 +5,9 @@ Test accumulation.
 from hamcrest import assert_that, contains
 
 from microcosm_eventsource.accumulation import (
+    addition,
     alias,
+    compose,
     current,
     keep,
     difference,
@@ -58,6 +60,28 @@ def test_keep():
     )
 
 
+def test_addition():
+    state = {
+        TaskEventType.CREATED,
+    }
+
+    assert_that(
+        addition(TaskEventType.ASSIGNED)(state, TaskEventType.ASSIGNED),
+        contains(TaskEventType.ASSIGNED, TaskEventType.CREATED),
+    )
+
+
+def test_addition_as_string():
+    state = {
+        TaskEventType.CREATED,
+    }
+
+    assert_that(
+        addition("ASSIGNED")(state, TaskEventType.ASSIGNED),
+        contains(TaskEventType.ASSIGNED, TaskEventType.CREATED),
+    )
+
+
 def test_difference():
     state = {
         TaskEventType.CREATED,
@@ -90,4 +114,19 @@ def test_union():
     assert_that(
         union()(state, TaskEventType.ASSIGNED),
         contains(TaskEventType.ASSIGNED, TaskEventType.CREATED),
+    )
+
+
+def test_compose():
+    state = {
+        TaskEventType.STARTED,
+        TaskEventType.REASSIGNED,
+    }
+
+    assert_that(
+        compose(
+            difference("STARTED"),
+            addition("COMPLETED"),
+        )(state, TaskEventType.COMPLETED),
+        contains(TaskEventType.COMPLETED, TaskEventType.REASSIGNED),
     )


### PR DESCRIPTION
This should support the case where an event adds itself and removes another event without touching any other accumulated state (e.g. flags)