### PR TITLE
Adds support for multiple children per parent in event model based on unique_parent flag

### DIFF
--- a/microcosm_eventsource/models.py
+++ b/microcosm_eventsource/models.py
@@ -94,11 +94,12 @@ class EventMeta(MetaClass):
             event_type=dct["__eventtype__"],
             table_name=dct["__tablename__"],
             table_args=dct.get("__table_args__", ()),
+            unique_parent=dct.get("__unique_parent__", True)
         ))
 
         return super(EventMeta, cls).__new__(cls, name, bases, dct)
 
-    def make_declarations(cls, container_name, event_type, table_name, table_args):
+    def make_declarations(cls, container_name, event_type, table_name, table_args, unique_parent):
         """
         Declare columns and indexes.
 
@@ -133,7 +134,7 @@ class EventMeta(MetaClass):
             container_id_name: Column(UUIDType, ForeignKey(container_id), nullable=False),
             "event_type": Column(EnumType(event_type), nullable=False),
             "clock": Column(Serial, server_default=FetchedValue(), nullable=False, unique=True),
-            "parent_id": Column(UUIDType, ForeignKey(parent_id), nullable=True, unique=True),
+            "parent_id": Column(UUIDType, ForeignKey(parent_id), nullable=True, unique=unique_parent),
             "state": Column(ARRAY(EnumType(event_type)), nullable=False, default=default_state),
             "version": Column(Integer, default=1, nullable=False),
 

--- a/microcosm_eventsource/models.py
+++ b/microcosm_eventsource/models.py
@@ -80,6 +80,12 @@ class EventMeta(MetaClass):
          -  `__eventtype__` a reference to the event type enumeration
          -  `__tablename__` the usual SQLAlchemy table name
 
+         Can optionally include the following declarations:
+
+         -  `__unique_parent__` a flag indicating whether or not a unique parent constraint is created
+         May be set to False in cases like having a unique parent for each version of the event
+         If the flag is set to False, a similar unique constraint should be set on the event class
+
         """
         if any(type(base) is EventMeta for base in bases):
             return super(EventMeta, cls).__new__(cls, name, bases, dct)

--- a/microcosm_eventsource/tests/fixtures.py
+++ b/microcosm_eventsource/tests/fixtures.py
@@ -134,3 +134,43 @@ def configure_task_crud(graph):
         new_event_schema=NewTaskEventSchema(),
         search_event_schema=SearchTaskEventSchema(),
     )
+
+
+class ActivityEventType(EventType):
+    CREATED = event_info(
+        follows=nothing(),
+    )
+    CANCELED = event_info(
+        follows=event("CREATED"),
+    )
+
+
+class Activity(UnixTimestampEntityMixin, Model):
+    __tablename__ = "activity"
+
+    description = Column(String)
+
+
+@add_metaclass(EventMeta)
+class ActivityEvent(UnixTimestampEntityMixin):
+    __tablename__ = "activity_event"
+    __eventtype__ = ActivityEventType
+    __container__ = Activity
+    # Supports multiple children per parent
+    __unique_parent__ = False
+
+    assignee = Column(String)
+
+
+@binding("activity_store")
+class ActivityStore(Store):
+
+    def __init__(self, graph):
+        super(ActivityStore, self).__init__(graph, Activity)
+
+
+@binding("activity_event_store")
+class ActivityEventStore(EventStore):
+
+    def __init__(self, graph):
+        super(ActivityEventStore, self).__init__(graph, ActivityEvent)


### PR DESCRIPTION
Why?

There are instances of the event model where this may be the desired behaviour.