### PR TITLE
Remove python2isms:

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,9 +1,8 @@
 [bumpversion]
-current_version = 0.10.0
+current_version = 1.0.0
 commit = False
 tag = False
 
 [bumpversion:file:setup.py]
 search = version = "{current_version}"
 replace = version = "{new_version}"
-

--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@
 
 machine:
   python:
-      version: 2.7.11
+      version: 3.6.2
 
 general:
   artifacts:
@@ -12,7 +12,12 @@ general:
 dependencies:
   override:
     - pip install tox tox-pyenv
-    - pyenv local 2.7.11 3.5.1  # Should correspond to pre-installed Python versions on CircleCI
+    - pyenv local 3.6.2
+
+database:
+  pre:
+     - createuser example
+     - createdb -O example example_test_db
 
 test:
   override:

--- a/microcosm_eventsource/event_types.py
+++ b/microcosm_eventsource/event_types.py
@@ -27,7 +27,7 @@ from microcosm_eventsource.accumulation import current
 from microcosm_eventsource.transitioning import nothing
 
 
-class EventTypeInfo(object):
+class EventTypeInfo:
     """
     Event type meta data.
 

--- a/microcosm_eventsource/factory.py
+++ b/microcosm_eventsource/factory.py
@@ -12,7 +12,7 @@ from microcosm_pubsub.conventions import created
 from werkzeug.exceptions import UnprocessableEntity
 
 
-class EventInfo(object):
+class EventInfo:
     """
     Encapsulate information needed to create an event.
 
@@ -38,7 +38,7 @@ class EventInfo(object):
         )
 
 
-class EventFactory(object):
+class EventFactory:
     """
     Base class for creating an event.
 

--- a/microcosm_eventsource/models.py
+++ b/microcosm_eventsource/models.py
@@ -20,7 +20,7 @@ from sqlalchemy_utils import UUIDType
 MetaClass = type(Model)
 
 
-class ColumnAlias(object):
+class ColumnAlias:
     """
     Descriptor to reference a column by a well known alias.
 
@@ -46,7 +46,7 @@ def join_event_types(event_types):
     )
 
 
-class BaseEvent(object):
+class BaseEvent:
 
     def is_similar_to(self, other):
         """

--- a/microcosm_eventsource/tests/fixtures.py
+++ b/microcosm_eventsource/tests/fixtures.py
@@ -2,8 +2,6 @@
 Test fixtures.
 
 """
-from six import add_metaclass
-
 from marshmallow import fields, Schema
 from microcosm.api import binding
 from microcosm_flask.fields import EnumField
@@ -70,8 +68,7 @@ class Task(UnixTimestampEntityMixin, Model):
     description = Column(String)
 
 
-@add_metaclass(EventMeta)
-class TaskEvent(UnixTimestampEntityMixin):
+class TaskEvent(UnixTimestampEntityMixin, metaclass=EventMeta):
     __tablename__ = "task_event"
     __eventtype__ = TaskEventType
     __container__ = Task
@@ -151,8 +148,7 @@ class Activity(UnixTimestampEntityMixin, Model):
     description = Column(String)
 
 
-@add_metaclass(EventMeta)
-class ActivityEvent(UnixTimestampEntityMixin):
+class ActivityEvent(UnixTimestampEntityMixin, metaclass=EventMeta):
     __tablename__ = "activity_event"
     __eventtype__ = ActivityEventType
     __container__ = Activity

--- a/microcosm_eventsource/tests/test_crud.py
+++ b/microcosm_eventsource/tests/test_crud.py
@@ -29,7 +29,7 @@ from microcosm_eventsource.tests.fixtures import (
 )
 
 
-class TestTaskEventCRUDRoutes(object):
+class TestTaskEventCRUDRoutes:
     def setup(self):
         loader = load_from_dict(
             sns_producer=dict(

--- a/microcosm_eventsource/tests/test_store.py
+++ b/microcosm_eventsource/tests/test_store.py
@@ -30,7 +30,7 @@ from microcosm_eventsource.tests.fixtures import (
 )
 
 
-class TestEventStore(object):
+class TestEventStore:
 
     def setup(self):
         self.graph = create_object_graph(

--- a/microcosm_eventsource/transitioning.py
+++ b/microcosm_eventsource/transitioning.py
@@ -14,7 +14,7 @@ def normalize(value):
     return event(value)
 
 
-class Nothing(object):
+class Nothing:
 
     def __call__(self, cls, state):
         return not(state)
@@ -25,7 +25,7 @@ class Nothing(object):
     __nonzero__ = __bool__
 
 
-class AllOf(object):
+class AllOf:
 
     def __init__(self, *args):
         self.args = args
@@ -39,7 +39,7 @@ class AllOf(object):
     __nonzero__ = __bool__
 
 
-class AnyOf(object):
+class AnyOf:
 
     def __init__(self, *args):
         self.args = args
@@ -53,7 +53,7 @@ class AnyOf(object):
     __nonzero__ = __bool__
 
 
-class ButNot(object):
+class ButNot:
 
     def __init__(self, arg):
         self.arg = arg
@@ -67,7 +67,7 @@ class ButNot(object):
     __nonzero__ = __bool__
 
 
-class Event(object):
+class Event:
 
     def __init__(self, name):
         self.name = name

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-eventsource"
-version = "0.10.0"
+version = "1.0.0"
 
 setup(
     name=project,
@@ -16,11 +16,11 @@ setup(
     zip_safe=False,
     keywords="microcosm",
     install_requires=[
-        "microcosm>=0.17.2",
-        "microcosm-flask>=0.70.0",
-        "microcosm-logging>=0.13.0",
-        "microcosm-postgres>=0.28.0",
-        "microcosm-pubsub>=0.28.1",
+        "microcosm>=2.0.0",
+        "microcosm-flask>=1.0.1",
+        "microcosm-logging>=1.0.0",
+        "microcosm-postgres>=1.0.0",
+        "microcosm-pubsub>=1.0.0",
     ],
     setup_requires=[
         "nose>=1.3.6",

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist = py36, lint
+
+[testenv]
+commands =
+    python setup.py nosetests --with-coverage --cover-package=microcosm_eventsource --cover-erase --cover-html
+    python setup.py sdist
+deps =
+    setuptools>=17.1
+
+[testenv:lint]
+commands=flake8 --max-line-length 120 microcosm_eventsource
+basepython=python3.6
+deps=
+    flake8
+    flake8-print


### PR DESCRIPTION
 - Build only 3.6
 - Remove `six` usage
 - Remove legacy class-object inheritance
 - Bump major version