### PR TITLE
Don't require clock, support global sorting by clock

### DIFF
--- a/microcosm_eventsource/resources.py
+++ b/microcosm_eventsource/resources.py
@@ -8,9 +8,7 @@ from microcosm_flask.paging import PageSchema
 
 
 class EventSchema(Schema):
-    clock = fields.Integer(
-        required=True,
-    )
+    clock = fields.Integer()
     createdTimestamp = fields.Float(
         attribute="created_timestamp",
         required=True,
@@ -39,4 +37,5 @@ class SearchEventSchema(PageSchema):
     min_clock = fields.Integer()
     max_clock = fields.Integer()
     parent_id = fields.UUID()
+    sort_by_clock = fields.Boolean()
     version = fields.Integer()

--- a/microcosm_eventsource/resources.py
+++ b/microcosm_eventsource/resources.py
@@ -8,7 +8,7 @@ from microcosm_flask.paging import PageSchema
 
 
 class EventSchema(Schema):
-    clock = fields.Integer()
+    clock = fields.Integer(allow_none=True)
     createdTimestamp = fields.Float(
         attribute="created_timestamp",
         required=True,

--- a/microcosm_eventsource/stores.py
+++ b/microcosm_eventsource/stores.py
@@ -105,11 +105,15 @@ class EventStore(Store):
 
         return super(EventStore, self)._filter(query, **kwargs)
 
-    def _order_by(self, query, **kwargs):
+    def _order_by(self, query, sort_by_clock=False, **kwargs):
         """
         Order events by logical clock.
 
         """
+        if sort_by_clock:
+            return query.order_by(
+                self.model_class.clock.desc(),
+            )
         return query.order_by(
             self.model_class.container_id.desc(),
             self.model_class.clock.desc(),


### PR DESCRIPTION
* Don't require setting the clock for `EventSchema` - used internally to sync resources but causing issues with `nextval` calculations
* Support explicit sorting by global clock