### PR TITLE
Change logic for AnyOf transition's __bool__

### DIFF
--- a/microcosm_eventsource/tests/fixtures.py
+++ b/microcosm_eventsource/tests/fixtures.py
@@ -24,6 +24,16 @@ from microcosm_eventsource.routes import configure_event_crud
 from microcosm_eventsource.stores import EventStore
 
 
+class FlexibleTaskEventType(EventType):
+    # Used to test is_initial
+    CREATED = event_info(
+        follows=any_of(
+            "CREATED",
+            nothing(),
+        ),
+    )
+
+
 class BasicTaskEventType(EventType):
     CREATED = event_info(
         follows=nothing(),

--- a/microcosm_eventsource/tests/test_event_types.py
+++ b/microcosm_eventsource/tests/test_event_types.py
@@ -4,7 +4,7 @@ Event type tests.
 """
 from hamcrest import assert_that, contains, equal_to, is_
 
-from microcosm_eventsource.tests.fixtures import TaskEventType
+from microcosm_eventsource.tests.fixtures import TaskEventType, FlexibleTaskEventType
 
 
 def test_accumulate_state():
@@ -66,6 +66,14 @@ def test_is_initial():
     """
     assert_that(TaskEventType.CREATED.is_initial, is_(equal_to(True)))
     assert_that(TaskEventType.STARTED.is_initial, is_(equal_to(False)))
+
+
+def test_is_initial_for_event_that_can_also_be_non_initial():
+    """
+    Events with no following information may be initial.
+
+    """
+    assert_that(FlexibleTaskEventType.CREATED.is_initial, is_(equal_to(True)))
 
 
 def test_assign_before_scheduled():

--- a/microcosm_eventsource/tests/test_transitioning.py
+++ b/microcosm_eventsource/tests/test_transitioning.py
@@ -16,8 +16,8 @@ from microcosm_eventsource.tests.fixtures import TaskEventType
 
 def test_any_of():
     transition = any_of(
-        "CREATED",
-        "ASSIGNED",
+        event("CREATED"),
+        event("ASSIGNED"),
     )
 
     assert_that(
@@ -30,14 +30,42 @@ def test_any_of():
     )
     assert_that(
         transition(TaskEventType, [TaskEventType.CREATED]),
+        is_(equal_to(True)),
+    )
+    assert_that(
+        transition(TaskEventType, []),
+        is_(equal_to(False)),
+    )
+
+
+def test_any_of_nothing():
+    transition = any_of(
+        nothing(),
+        event("CREATED"),
+    )
+
+    assert_that(
+        bool(transition),
+        is_(equal_to(False)),
+    )
+    assert_that(
+        transition(TaskEventType, [TaskEventType.CREATED, TaskEventType.ASSIGNED]),
+        is_(equal_to(True)),
+    )
+    assert_that(
+        transition(TaskEventType, [TaskEventType.CREATED]),
+        is_(equal_to(True)),
+    )
+    assert_that(
+        transition(TaskEventType, []),
         is_(equal_to(True)),
     )
 
 
 def test_all_of():
     transition = all_of(
-        "CREATED",
-        "ASSIGNED",
+        event("CREATED"),
+        event("ASSIGNED"),
     )
 
     assert_that(
@@ -51,12 +79,65 @@ def test_all_of():
     assert_that(
         transition(TaskEventType, [TaskEventType.CREATED]),
         is_(equal_to(False)),
+    )
+    assert_that(
+        transition(TaskEventType, []),
+        is_(equal_to(False)),
+    )
+
+
+def test_all_of_some_nothing():
+    transition = all_of(
+        nothing(),
+        event("CREATED"),
+        event("ASSIGNED"),
+    )
+
+    assert_that(
+        bool(transition),
+        is_(equal_to(True)),
+    )
+    assert_that(
+        transition(TaskEventType, [TaskEventType.CREATED, TaskEventType.ASSIGNED]),
+        is_(equal_to(False)),
+    )
+    assert_that(
+        transition(TaskEventType, [TaskEventType.CREATED]),
+        is_(equal_to(False)),
+    )
+    assert_that(
+        transition(TaskEventType, []),
+        is_(equal_to(False)),
+    )
+
+
+def test_all_of_nothing():
+    transition = all_of(
+        nothing(),
+        nothing(),
+    )
+
+    assert_that(
+        bool(transition),
+        is_(equal_to(False)),
+    )
+    assert_that(
+        transition(TaskEventType, [TaskEventType.CREATED, TaskEventType.ASSIGNED]),
+        is_(equal_to(False)),
+    )
+    assert_that(
+        transition(TaskEventType, [TaskEventType.CREATED]),
+        is_(equal_to(False)),
+    )
+    assert_that(
+        transition(TaskEventType, []),
+        is_(equal_to(True)),
     )
 
 
 def test_but_not():
     transition = but_not(
-        "ASSIGNED",
+        event("ASSIGNED"),
     )
 
     assert_that(
@@ -73,10 +154,29 @@ def test_but_not():
     )
 
 
-def test_event():
-    transition = event(
-        "ASSIGNED",
+def test_but_not_nothing():
+    transition = but_not(nothing())
+
+    assert_that(
+        bool(transition),
+        is_(equal_to(True)),
     )
+    assert_that(
+        transition(TaskEventType, [TaskEventType.CREATED, TaskEventType.ASSIGNED]),
+        is_(equal_to(True)),
+    )
+    assert_that(
+        transition(TaskEventType, [TaskEventType.CREATED]),
+        is_(equal_to(True)),
+    )
+    assert_that(
+        transition(TaskEventType, []),
+        is_(equal_to(False)),
+    )
+
+
+def test_event():
+    transition = event("ASSIGNED")
 
     assert_that(
         bool(transition),

--- a/microcosm_eventsource/transitioning.py
+++ b/microcosm_eventsource/transitioning.py
@@ -56,7 +56,7 @@ class AllOf(Transition):
         return all(normalize(arg)(cls, state) for arg in self.args)
 
     def __bool__(self):
-        return all(arg for arg in self.args)
+        return any(arg for arg in self.args)
 
     __nonzero__ = __bool__
 
@@ -70,7 +70,7 @@ class AnyOf(Transition):
         return any(normalize(arg)(cls, state) for arg in self.args)
 
     def __bool__(self):
-        return any(arg for arg in self.args)
+        return all(arg for arg in self.args)
 
     __nonzero__ = __bool__
 


### PR DESCRIPTION
`bool(AnyOf(*args))` should return false if `nothing()` is one of the args, since that expresses that the event could be initial.