### PR TITLE
Improve DDL management for custom functions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include microcosm_eventsource *.ddl

--- a/microcosm_eventsource/ddl/last_agg.create.ddl
+++ b/microcosm_eventsource/ddl/last_agg.create.ddl
@@ -1,0 +1,4 @@
+CREATE AGGREGATE last_agg (anyelement) (
+      SFUNC = last_agg_sfunc,
+      STYPE = anyelement
+);

--- a/microcosm_eventsource/ddl/last_agg.drop.ddl
+++ b/microcosm_eventsource/ddl/last_agg.drop.ddl
@@ -1,0 +1,1 @@
+DROP AGGREGATE IF EXISTS last_agg (anyelement);

--- a/microcosm_eventsource/ddl/last_agg_sfunc.create.ddl
+++ b/microcosm_eventsource/ddl/last_agg_sfunc.create.ddl
@@ -1,0 +1,7 @@
+CREATE OR REPLACE FUNCTION last_agg_sfunc (state anyelement, value anyelement)
+       RETURNS anyelement
+       LANGUAGE SQL
+       IMMUTABLE
+AS $$
+  SELECT coalesce(value, state);
+$$;

--- a/microcosm_eventsource/ddl/last_agg_sfunc.drop.ddl
+++ b/microcosm_eventsource/ddl/last_agg_sfunc.drop.ddl
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS last_agg_sfunc (state anyelement, value anyelement);

--- a/microcosm_eventsource/stores/rollup.py
+++ b/microcosm_eventsource/stores/rollup.py
@@ -2,10 +2,10 @@
 Rolled up event store.
 
 """
-from sqlalchemy import func
 from sqlalchemy.orm import aliased
 from sqlalchemy.orm.exc import NoResultFound
 
+from microcosm_eventsource.func import ranked
 from microcosm_eventsource.models.rollup import RollUp
 from microcosm_postgres.context import SessionContext
 from microcosm_postgres.errors import ModelNotFoundError
@@ -163,10 +163,7 @@ class RollUpStore:
         # rank() OVER (partition by <container_id> order by clock desc)
         # ... <possibly more>
         return dict(
-            rank=func.rank().over(
-                order_by=self.event_type.clock.desc(),
-                partition_by=self.event_type.container_id,
-            ),
+            rank=ranked(self.event_type),
         )
 
     def _rollup_query(self, container, aggregate, **kwargs):

--- a/microcosm_eventsource/tests/stores/test_rollup.py
+++ b/microcosm_eventsource/tests/stores/test_rollup.py
@@ -40,7 +40,7 @@ class TaskRollUpStore(RollUpStore):
     def _aggregate(self, **kwargs):
         aggregate = super()._aggregate(**kwargs)
         aggregate.update(
-            assignee=last.over_(TaskEvent.assignee),
+            assignee=last.of(TaskEvent.assignee),
         )
         return aggregate
 
@@ -62,9 +62,7 @@ class TestRolledUpEventStore:
         self.store = TaskRollUpStore(self.graph)
 
         self.context = SessionContext(self.graph)
-        last.drop(self.graph.postgres)
         self.context.recreate_all()
-        last.create(self.graph.postgres)
         self.context.open()
 
         with transaction():

--- a/microcosm_eventsource/tests/test_func.py
+++ b/microcosm_eventsource/tests/test_func.py
@@ -28,9 +28,7 @@ class TestLast:
         )
 
         self.context = SessionContext(self.graph)
-        last.drop(self.graph.postgres)
         self.context.recreate_all()
-        last.create(self.graph.postgres)
         self.context.open()
 
         with transaction():
@@ -69,10 +67,7 @@ class TestLast:
     def test_last(self):
         rows = self.context.session.query(
             TaskEvent.assignee,
-            last(TaskEvent.assignee).over(
-                order_by=TaskEvent.clock.asc(),
-                partition_by=TaskEvent.container_id,
-            ),
+            last.of(TaskEvent.assignee),
         ).order_by(
             TaskEvent.clock.desc(),
         ).all()


### PR DESCRIPTION
Changes:
 -  DDL is not activated via sqlalchemy events; this ensures that unit tests work

 -  DDL is not exposed via a `create(connection)` or `drop(connection)` method;
    Downstream projects will have to generate their own migrations.

 -  Small API change from `last.over_(foo)` to `last.of(foo)`