### PR TITLE
order_by subquery before applying limit

### DIFF
--- a/microcosm_eventsource/stores/rollup.py
+++ b/microcosm_eventsource/stores/rollup.py
@@ -150,7 +150,9 @@ class RollUpStore:
         # SELECT * FROM <container> WHERE <filter>
         return self._container_subquery(
             self.container_store._filter(
-                self.container_store._query(),
+                self.container_store._order_by(
+                    self.container_store._query(),
+                ),
                 **kwargs
             )
         )


### PR DESCRIPTION
Order_by before applying limit to the model subquery
Why?
To return the right results - without it pagination can cause some bugs
See also: https://github.com/globality-corp/microcosm-postgres/pull/41

Note:
We apply the order by twice:
* first - on the model subquery
* then again on the joined last_model_event + model subquery

We can avoid it by changing the way that we're querying data (join the event, not the model) - but it will require bigger PR

Generated SQL change:

```
SELECT
    anon_1.project_event_id AS anon_1_project_event_id,
    anon_1.project_id AS anon_1_project_id,
    ...
FROM (
    SELECT
        project_event.id AS project_event_id,
        project.id AS project_id,
        ...
        rank() OVER (PARTITION BY project_event.project_id ORDER BY project_event.clock DESC) AS anon_2,
        ...
    ORDER BY project_event.clock ASC
) AS anon_7
FROM project_event JOIN (
    SELECT project.id AS id
    FROM project
-- NEW:    ORDER BY project.created_at DESC
    LIMIT 20 OFFSET 0
) AS project
ON project.id = project_event.project_id
ORDER BY project.created_at DESC
) AS anon_1
WHERE anon_1.anon_2 = 1
```