### PR TITLE
func.last_of supports filter_by

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.6.1
+current_version = 1.8.2
 commit = False
 tag = False
 

--- a/microcosm_eventsource/func.py
+++ b/microcosm_eventsource/func.py
@@ -36,13 +36,13 @@ class last(FunctionElement):
     name = "last"
 
     @classmethod
-    def of(cls, column):
+    def of(cls, column, *filter_by):
         """
         Generate a window function over an event's column.
 
         """
         event = column.class_
-        return cls(column).over(
+        return cls(column).filter(*filter_by).over(
             order_by=event.clock.asc(),
             partition_by=event.container_id,
         )

--- a/microcosm_eventsource/tests/test_func.py
+++ b/microcosm_eventsource/tests/test_func.py
@@ -79,3 +79,22 @@ class TestLast:
             contains("Alice", "Alice"),
             contains(None, None),
         ))
+
+    def test_last_filter_by(self):
+        rows = self.context.session.query(
+            TaskEvent.assignee,
+            last.of(
+                TaskEvent.assignee,
+                TaskEvent.event_type == TaskEventType.ASSIGNED,
+            ),
+        ).order_by(
+            TaskEvent.clock.desc(),
+        ).all()
+
+        assert_that(rows, contains(
+            contains(None, "Alice"),
+            contains("Bob", "Alice"),
+            contains(None, "Alice"),
+            contains("Alice", "Alice"),
+            contains(None, None),
+        ))

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-eventsource"
-version = "1.6.1"
+version = "1.8.2"
 
 setup(
     name=project,


### PR DESCRIPTION
`last.of` is extremely useful function, however, sometimes we want to filter the aggregated events. This PR suggests a way to filter the aggregated events.
Example use case: two event types "ASSIGNED" and "REASSIGNED" uses the same column to mark a person - if we want to find the last "ASSIGNED" person (but we don't about the `REASSIGNED`) - we have to use a filter.

Because `last.of` it is not part of sqlalchemy we cannot call `cls.filter(*filter_by).last()` or `last.of(cls).filter(*filter_by)`- instead we can either:
1. add `filter_by=None` array arg
2. add `*filter_by` arg (suggested)
3. rebuild `last` class - `last(cls).filter(*filter_by).build()`