### PR TITLE
Release/last_of.filter_by

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.8.1
+current_version = 1.8.2
 commit = False
 tag = False
 

--- a/microcosm_eventsource/func.py
+++ b/microcosm_eventsource/func.py
@@ -36,13 +36,13 @@ class last(FunctionElement):
     name = "last"
 
     @classmethod
-    def of(cls, column):
+    def of(cls, column, *filter_by):
         """
         Generate a window function over an event's column.
 
         """
         event = column.class_
-        return cls(column).over(
+        return cls(column).filter(*filter_by).over(
             order_by=event.clock.asc(),
             partition_by=event.container_id,
         )

--- a/microcosm_eventsource/tests/test_func.py
+++ b/microcosm_eventsource/tests/test_func.py
@@ -79,3 +79,22 @@ class TestLast:
             contains("Alice", "Alice"),
             contains(None, None),
         ))
+
+    def test_last_filter_by(self):
+        rows = self.context.session.query(
+            TaskEvent.assignee,
+            last.of(
+                TaskEvent.assignee,
+                TaskEvent.event_type == TaskEventType.ASSIGNED,
+            ),
+        ).order_by(
+            TaskEvent.clock.desc(),
+        ).all()
+
+        assert_that(rows, contains(
+            contains(None, "Alice"),
+            contains("Bob", "Alice"),
+            contains(None, "Alice"),
+            contains("Alice", "Alice"),
+            contains(None, None),
+        ))

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-eventsource"
-version = "1.8.1"
+version = "1.8.2"
 
 setup(
     name=project,


### PR DESCRIPTION
Release https://github.com/globality-corp/microcosm-eventsource/pull/24

last.of is extremely useful function, however, sometimes we want to filter the aggregated events. This PR suggests a way to filter the aggregated events.
