### PR TITLE
event_type.all_transitions() helper

### DIFF
--- a/microcosm_eventsource/event_types.py
+++ b/microcosm_eventsource/event_types.py
@@ -170,7 +170,7 @@ class EventType(Enum):
         return version
 
     @classmethod
-    def intial_states(cls):
+    def initial_states(cls):
         """
         Return a generator of all initial states.
 
@@ -185,9 +185,9 @@ class EventType(Enum):
         """
         # Prefer to use frozenset and not set to represent states in this context
         # Hashable frozenset allows us to easily avoid repeating the same state
-        intial_states = list(cls.intial_states())
-        next_states = intial_states
-        known_states = set(intial_states)
+        initial_states = list(cls.initial_states())
+        next_states = initial_states
+        known_states = set(initial_states)
 
         while True:
             if not next_states:
@@ -210,12 +210,12 @@ class EventType(Enum):
         Note: it can return the same state or event twice (but all uniqu)
 
         """
-        intial_states = list(cls.intial_states())
-        intial_states_and_events = [(state, list(state)[0]) for state in intial_states]
-        yield from intial_states_and_events
-        next_states = intial_states
-        known_states = set(intial_states)
-        known_states_and_events = set(intial_states_and_events)
+        initial_states = list(cls.initial_states())
+        initial_states_and_events = [(state, list(state)[0]) for state in initial_states]
+        yield from initial_states_and_events
+        next_states = initial_states
+        known_states = set(initial_states)
+        known_states_and_events = set(initial_states_and_events)
 
         while True:
             if not next_states:

--- a/microcosm_eventsource/event_types.py
+++ b/microcosm_eventsource/event_types.py
@@ -204,6 +204,37 @@ class EventType(Enum):
                     known_states.add(new_state)
 
     @classmethod
+    def all_states_and_events(cls):
+        """
+        Return a generator of all allowed (state, event_type) combinations
+        Note: it can return the same state or event twice (but all uniqu)
+
+        """
+        intial_states = list(cls.intial_states())
+        intial_states_and_events = [(state, list(state)[0]) for state in intial_states]
+        yield from intial_states_and_events
+        next_states = intial_states
+        known_states = set(intial_states)
+        known_states_and_events = set(intial_states_and_events)
+
+        while True:
+            if not next_states:
+                return
+            current_states = next_states
+            next_states = []
+            for state in current_states:
+                for event_type in cls.available_transitions(state):
+                    new_state = frozenset(event_type.accumulate_state(state))
+                    if (new_state, event_type) in known_states_and_events:
+                        continue
+                    known_states_and_events.add((new_state, event_type))
+                    yield new_state, event_type
+                    if new_state in known_states:
+                        continue
+                    next_states.append(new_state)
+                    known_states.add(new_state)
+
+    @classmethod
     def all_transitions(cls, states=None):
         """
         Return a generator of all allowed transitions as a tuple of (initial state, new state, event type).

--- a/microcosm_eventsource/tests/test_event_types.py
+++ b/microcosm_eventsource/tests/test_event_types.py
@@ -216,7 +216,7 @@ def test_initial_states():
     expected_states = [
         {TaskEventType.CREATED},
     ]
-    assert_that(list(TaskEventType.intial_states()), contains_inanyorder(*expected_states))
+    assert_that(list(TaskEventType.initial_states()), contains_inanyorder(*expected_states))
 
 
 def test_all_states():

--- a/microcosm_eventsource/tests/test_event_types.py
+++ b/microcosm_eventsource/tests/test_event_types.py
@@ -237,6 +237,29 @@ def test_all_states():
     assert_that(list(TaskEventType.all_states()), contains_inanyorder(*expected_states))
 
 
+def test_all_states_and_events():
+    """
+    Find all allowed states.
+
+    """
+    states_and_events = [
+        (state, event_type)
+        for (state, event_type)
+        in TaskEventType.all_states_and_events()
+        if state in (
+            {TaskEventType.CREATED},
+            {TaskEventType.CREATED, TaskEventType.ASSIGNED, TaskEventType.SCHEDULED},
+        )
+    ]
+    expected_states_and_events = [
+        ({TaskEventType.CREATED}, TaskEventType.CREATED),
+        ({TaskEventType.CREATED}, TaskEventType.REVISED),
+        ({TaskEventType.CREATED, TaskEventType.ASSIGNED, TaskEventType.SCHEDULED}, TaskEventType.ASSIGNED),
+        ({TaskEventType.CREATED, TaskEventType.ASSIGNED, TaskEventType.SCHEDULED}, TaskEventType.SCHEDULED),
+    ]
+    assert_that(states_and_events, contains_inanyorder(*expected_states_and_events))
+
+
 def test_all_transitions():
     """
     Find all allowed transitions.

--- a/microcosm_eventsource/tests/test_event_types.py
+++ b/microcosm_eventsource/tests/test_event_types.py
@@ -208,6 +208,17 @@ def test_completed_is_terminal():
     assert_that(TaskEventType.CANCELED.may_transition(state), is_(equal_to(False)))
 
 
+def test_initial_states():
+    """
+    Find all initial states.
+
+    """
+    expected_states = [
+        {TaskEventType.CREATED},
+    ]
+    assert_that(list(TaskEventType.intial_states()), contains_inanyorder(*expected_states))
+
+
 def test_all_states():
     """
     Find all allowed states.
@@ -224,6 +235,29 @@ def test_all_states():
         {TaskEventType.CREATED, TaskEventType.SCHEDULED, TaskEventType.ASSIGNED},
     ]
     assert_that(list(TaskEventType.all_states()), contains_inanyorder(*expected_states))
+
+
+def test_all_transitions():
+    """
+    Find all allowed transitions.
+
+    """
+    from_states = [
+        {TaskEventType.CREATED},
+        {TaskEventType.CREATED, TaskEventType.SCHEDULED},
+    ]
+    expected_states = [
+        ({TaskEventType.CREATED}, {TaskEventType.CREATED}, TaskEventType.REVISED),
+        ({TaskEventType.CREATED}, {TaskEventType.CREATED, TaskEventType.ASSIGNED}, TaskEventType.ASSIGNED),
+        ({TaskEventType.CREATED}, {TaskEventType.CREATED, TaskEventType.SCHEDULED}, TaskEventType.SCHEDULED),
+        ({TaskEventType.CREATED, TaskEventType.SCHEDULED}, {TaskEventType.CREATED}, TaskEventType.REVISED),
+        (
+            {TaskEventType.CREATED, TaskEventType.SCHEDULED},
+            {TaskEventType.CREATED, TaskEventType.SCHEDULED, TaskEventType.ASSIGNED},
+            TaskEventType.ASSIGNED,
+        ),
+    ]
+    assert_that(list(TaskEventType.all_transitions(from_states)), contains_inanyorder(*expected_states))
 
 
 def test_auto_transition_events():


### PR DESCRIPTION
3 new classmethods similar to `all_states` that help us to view the state machine:
* `initial_states` - return a generator of all the initial states
*  `all_transitions ` returns a generator of `(old_state, new_state, event_type)` of all allowed transitions 
* `all_states_and_events` returns a generator similar to `all_states` - that also returns the relevant last event type - some states can have different last event types.

`len(all_states_and_events) >= len(all_states) >= len(initial_states)`
`len(all_states_and_events) ~ len(all_transitions)`

How can we use those functions?
* to create transition graphs
* to validate states saved in the db - especially relevant for migrations debugging & help checks - in a near future PR