### PR TITLE
Publish created(ModelEvent)

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.8.3
+current_version = 1.8.4
 commit = False
 tag = False
 

--- a/microcosm_eventsource/factory.py
+++ b/microcosm_eventsource/factory.py
@@ -188,19 +188,24 @@ class EventFactory:
         uri_kwargs = self.make_uri_kwargs(event_info)
         if self.publish_event_pubsub:
             event_info.publish_event(
-                media_type=created("{}.{}".format(
-                    name_for(self.event_store.model_class),
-                    event_info.event.event_type.name,
-                )),
+                media_type=self.make_media_type(event_info),
                 **uri_kwargs,
             )
         if self.publish_model_pubsub:
             event_info.publish_event(
-                media_type=created("{}".format(
-                    name_for(self.event_store.model_class),
-                )),
+                media_type=self.make_media_type(event_info, True),
                 **uri_kwargs,
             )
+
+    def make_media_type(self, event_info, discard_event_type=False):
+        if discard_event_type:
+            return created("{}".format(
+                name_for(self.event_store.model_class),
+            ))
+        return created("{}.{}".format(
+            name_for(self.event_store.model_class),
+            event_info.event.event_type.name,
+        ))
 
     def make_uri_kwargs(self, event_info):
         uri_kwargs = dict(_external=True)

--- a/microcosm_eventsource/tests/fixtures.py
+++ b/microcosm_eventsource/tests/fixtures.py
@@ -18,6 +18,7 @@ from microcosm_eventsource.accumulation import alias, keep, union
 from microcosm_eventsource.controllers import EventController
 from microcosm_eventsource.transitioning import all_of, any_of, but_not, event, nothing
 from microcosm_eventsource.event_types import event_info, EventType, EventTypeUnion
+from microcosm_eventsource.factory import EventFactory
 from microcosm_eventsource.models import EventMeta
 from microcosm_eventsource.resources import EventSchema, SearchEventSchema
 from microcosm_eventsource.routes import configure_event_crud
@@ -144,6 +145,17 @@ class TaskEventController(EventController):
         self.ns = Namespace(
             subject=TaskEvent,
             version="v1",
+        )
+
+    def get_event_factory_kwargs(self):
+        return {}
+
+    @property
+    def event_factory(self):
+        return EventFactory(
+            event_store=self.store,
+            identifier_key=self.identifier_key,
+            **self.get_event_factory_kwargs(),
         )
 
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-eventsource"
-version = "1.8.3"
+version = "1.8.4"
 
 setup(
     name=project,


### PR DESCRIPTION
Sometimes, we want to publish a single message for every new event (`created(TaskEvent)`) instead of separate message for every event type (`created(TaskEvent.Created)`, `created(TaskEvent.Closed)`) - and sometimes both / no message at all. 

Allow to configure the behavior when initializing the factory. Default behavior is still the same.