### PR TITLE
EventController.sns_producer to member

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.8.4
+current_version = 1.8.5
 commit = False
 tag = False
 

--- a/microcosm_eventsource/controllers.py
+++ b/microcosm_eventsource/controllers.py
@@ -9,9 +9,9 @@ from microcosm_eventsource.factory import EventFactory
 
 class EventController(CRUDStoreAdapter):
 
-    @property
-    def sns_producer(self):
-        return self.graph.sns_producer
+    def __init__(self, graph, store):
+        super().__init__(graph, store)
+        self.sns_producer = graph.sns_producer
 
     @property
     def event_factory(self):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-eventsource"
-version = "1.8.4"
+version = "1.8.5"
 
 setup(
     name=project,


### PR DESCRIPTION
Change `self.sns_producer` to be a member instead of a property
Why?
We have assumptions in other places (such as https://github.com/globality-corp/microcosm-pubsub/blob/develop/microcosm_pubsub/producer.py#L199) that `self.sns_producer` is a member and not a property. We can change the assumption - but I think this assumption is fine.
