### PR TITLE
Migration functions: replace_event_type, delete_event_type & delete_events

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.9.0
+current_version = 1.9.1
 commit = False
 tag = False
 

--- a/microcosm_eventsource/ddl/array_sort_unique.create.ddl
+++ b/microcosm_eventsource/ddl/array_sort_unique.create.ddl
@@ -1,0 +1,10 @@
+/*
+ * array_sort_unique(ANYARRAY)
+ *
+ * Return sorted and unique array
+ */
+CREATE OR REPLACE FUNCTION array_sort_unique (ANYARRAY)
+RETURNS ANYARRAY LANGUAGE SQL
+AS $$
+SELECT ARRAY(SELECT DISTINCT unnest($1) ORDER BY 1)
+$$;

--- a/microcosm_eventsource/ddl/array_sort_unique.drop.ddl
+++ b/microcosm_eventsource/ddl/array_sort_unique.drop.ddl
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS array_sort_unique (ANYARRAY);

--- a/microcosm_eventsource/ddl/proc_event_type_delete.create.ddl
+++ b/microcosm_eventsource/ddl/proc_event_type_delete.create.ddl
@@ -1,0 +1,42 @@
+/*
+ * proc_event_type_delete(table_name, old_event_type, model_id_row_name)
+ *
+ * Should be only used by data migrations scripts.
+ * Delete events with old_event_type and remove it from states,
+ * Must pass model_id_row_name - the row name that links to the parent model
+ * (Example: for company_event table, the model_id_row_name should be company_id)
+ *
+ * Example:
+ * SELECT proc_event_type_delete('task_event', 'SCHEDULED', 'task_id');
+ *
+ * Details:
+ * - Updates parent_id of relevant child events
+ * - Updates the state column (Ensures that the state is sorted and has unique events)
+ * - Does not promise valid events or transitions.
+ * - Cannot be used if model.__unique_parent__ is set to False (missing table_names_parent_id_key constraint),
+ */
+CREATE OR REPLACE FUNCTION proc_event_type_delete(
+    table_name regclass,
+    old_event_type character varying(255),
+    model_id_row_name character varying(255)) RETURNS void AS
+$func$
+BEGIN
+    EXECUTE format(
+        '
+            CREATE TEMP TABLE events_to_remove_%%1$s_%%2$s AS (
+                SELECT id
+                FROM %%1$s
+                WHERE event_type = ''%%2$s''
+            );
+            SELECT proc_events_delete(''%%1$s'', ''events_to_remove_%%1$s_%%2$s'', ''%%3$s'');
+
+            UPDATE %%1$s
+            SET state = array_remove(state, ''%%2$s'')
+            WHERE ''%%2$s'' = ANY(state);
+        ',
+        table_name,
+        old_event_type,
+        model_id_row_name
+    );
+END
+$func$  LANGUAGE plpgsql;

--- a/microcosm_eventsource/ddl/proc_event_type_delete.drop.ddl
+++ b/microcosm_eventsource/ddl/proc_event_type_delete.drop.ddl
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS proc_event_type_delete(regclass, character varying(255), character varying(255));

--- a/microcosm_eventsource/ddl/proc_event_type_replace.create.ddl
+++ b/microcosm_eventsource/ddl/proc_event_type_replace.create.ddl
@@ -1,0 +1,37 @@
+/*
+ * proc_event_type_replace(table_name, old_event_type, new_event_type)
+ *
+ * Should be only used by data migrations scripts.
+ * Replaces old_event_type with new_event_type in table_name table,
+ *
+ * Example:
+ * SELECT proc_event_type_replace('task_event', 'SCHEDULED', 'CANCELED');
+ *
+ * Details:
+ * - Updates the event_type column
+ * - Updates the state column (Ensures that the state is sorted and has unique events)
+ * - Does not promise valid events or transitions.
+ */
+
+CREATE OR REPLACE FUNCTION proc_event_type_replace(
+    table_name regclass,
+    old_event_type character varying(255),
+    new_event_type character varying(255)) RETURNS void AS
+$func$
+BEGIN
+    EXECUTE format(
+        '
+            UPDATE %%1$s
+            SET event_type = ''%%3$s''
+            WHERE event_type = ''%%2$s'';
+
+            UPDATE %%1$s
+            SET state = array_sort_unique(array_replace(state, ''%%2$s'', ''%%3$s''))
+            WHERE ''%%2$s'' = ANY(state);
+        ',
+        table_name,
+        old_event_type,
+        new_event_type
+    );
+END
+$func$  LANGUAGE plpgsql;

--- a/microcosm_eventsource/ddl/proc_event_type_replace.drop.ddl
+++ b/microcosm_eventsource/ddl/proc_event_type_replace.drop.ddl
@@ -1,0 +1,1 @@
+DROP FUNCTION IF EXISTS proc_event_type_replace(regclass, character varying(255), character varying(255));

--- a/microcosm_eventsource/ddl/proc_events_delete.create.ddl
+++ b/microcosm_eventsource/ddl/proc_events_delete.create.ddl
@@ -1,0 +1,109 @@
+/*
+ * proc_events_delete(table_name, events_to_delete_table_name, model_id_row_name)
+ *
+ * Should be only used by data migrations scripts.
+ * Deletes events from table table_name - a valid microcosm-event-source event table.
+ * Pass the events to delete as column id from table events_to_delete_table_name.
+ * Must pass model_id_row_name - the row name that links to the parent model
+ * (Example: for company_event table, the model_id_row_name should be company_id)
+ *
+ * Example:
+ * CREATE TEMP TABLE events_to_remove AS (SELECT id FROM task_event WHERE event_type='SCHEDULED');
+ * SELECT proc_events_delete('task_event', 'events_to_remove', 'task_id');
+ *
+ * Details:
+ * - Won't update the state (see: proc_event_type_delete function)
+ * - Deletes the relevant events
+ * - Updates the parent_id of the child events
+ * - Cannot be used if model.__unique_parent__ is set to False (missing table_names_parent_id_key constraint),
+ *   If thats the case - use proc_events_delete_with_no_parent_id_constraint function instead.
+ */
+CREATE OR REPLACE FUNCTION proc_events_delete(
+    table_name regclass,
+    events_to_delete_table_name regclass,
+    model_id_row_name character varying(255)) RETURNS void AS
+$func$
+BEGIN
+    EXECUTE format(
+        '
+            ALTER TABLE %%1$s DROP CONSTRAINT %%1$s_parent_id_key;
+            SELECT proc_events_delete_with_no_parent_id_constraint(''%%1$s'', ''%%2$s'', ''%%3$s'');
+            ALTER TABLE %%1$s ADD CONSTRAINT %%1$s_parent_id_key UNIQUE (parent_id);
+        ',
+        table_name,
+        events_to_delete_table_name,
+        model_id_row_name
+    );
+END
+$func$  LANGUAGE plpgsql;
+
+
+/*
+ * proc_events_delete_with_no_parent_id_constraint(table_name, events_to_delete_table_name, model_id_row_name)
+ *
+ * Should be only used by data migrations scripts.
+ * Same as proc_events_delete function but for use if model.__unique_parent__ is set to False
+ * (missing table_names_parent_id_key constraint),
+ */
+CREATE OR REPLACE FUNCTION proc_events_delete_with_no_parent_id_constraint(
+    table_name regclass,
+    events_to_delete_table_name regclass,
+    model_id_row_name character varying(255)) RETURNS void AS
+$func$
+BEGIN
+    EXECUTE format(
+        '
+            -- Temporary drop the constraint, bring it back before the end of the transaction.
+            ALTER TABLE %%1$s DROP CONSTRAINT %%1$s_parent_id_fkey;
+
+            -- Updates parent_id of events if the current parent_id is going to be deleted.
+            -- Handle the case that the new parent_id is not the parent_id of the current parent. 
+            -- (For example from the events chain a->b->c->d, both events b and c are going to be deleted) 
+            -- Skip events that are going to be deleted anyway.
+            -- Skip the new"top events" - events that are going to have no parent id.
+            WITH child_events AS (
+                SELECT child_event.id, child_event.clock, child_event.%%3$s
+                FROM %%1$s AS child_event
+                JOIN %%2$s AS parent_event
+                ON parent_event.id = child_event.parent_id
+                LEFT JOIN %%2$s AS events_to_avoid
+                ON events_to_avoid.id = child_event.id
+                WHERE events_to_avoid.id is null
+            ),
+            new_child_events_parents AS (
+                SELECT distinct on (child_events.clock)
+                    child_events.id AS child_event_id,
+                    new_parent.id AS new_parent_id
+                FROM %%1$s AS new_parent
+                RIGHT JOIN child_events
+                ON new_parent.%%3$s = child_events.%%3$s
+                AND new_parent.clock < child_events.clock
+                LEFT JOIN %%2$s AS events_to_avoid
+                ON events_to_avoid.id = new_parent.id
+                WHERE events_to_avoid.id is null
+                ORDER BY child_events.clock, new_parent.clock desc
+            )
+            UPDATE %%1$s
+            SET parent_id = new_child_events_parents.new_parent_id
+            FROM new_child_events_parents
+            WHERE %%1$s.id = new_child_events_parents.child_event_id;
+
+            -- Delete the events
+            DELETE FROM %%1$s
+            USING %%2$s
+            WHERE %%1$s.id = %%2$s.id;
+
+            -- Set null parent id to the new "top events".
+            UPDATE %%1$s
+            SET parent_id = null
+            FROM %%2$s
+            WHERE %%1$s.parent_id = %%2$s.id;
+
+            ALTER TABLE %%1$s ADD CONSTRAINT %%1$s_parent_id_fkey FOREIGN KEY (parent_id) REFERENCES %%1$s(id);
+        ',
+        table_name,
+        events_to_delete_table_name,
+        model_id_row_name
+    );
+END
+$func$  LANGUAGE plpgsql;

--- a/microcosm_eventsource/ddl/proc_events_delete.drop.ddl
+++ b/microcosm_eventsource/ddl/proc_events_delete.drop.ddl
@@ -1,0 +1,2 @@
+DROP FUNCTION IF EXISTS proc_events_delete(regclass, regclass, character varying(255));
+DROP FUNCTION IF EXISTS proc_events_delete_with_no_parent_id_constraint(regclass, character varying(255), character varying(255));

--- a/microcosm_eventsource/func.py
+++ b/microcosm_eventsource/func.py
@@ -19,12 +19,26 @@ def load_ddl(name, action):
 listen(
     Model.metadata,
     "after_create",
-    DDL(load_ddl("last_agg_sfunc", "create") + load_ddl("last_agg", "create")),
+    DDL(
+        load_ddl("array_sort_unique", "create") +
+        load_ddl("proc_events_delete", "create") +
+        load_ddl("proc_event_type_delete", "create") +
+        load_ddl("last_agg_sfunc", "create") +
+        load_ddl("last_agg", "create") +
+        load_ddl("proc_event_type_replace", "create")
+    ),
 )
 listen(
     Model.metadata,
     "after_drop",
-    DDL(load_ddl("last_agg", "drop") + load_ddl("last_agg_sfunc", "drop")),
+    DDL(
+        load_ddl("array_sort_unique", "drop") +
+        load_ddl("proc_events_delete", "drop") +
+        load_ddl("proc_event_type_delete", "drop") +
+        load_ddl("last_agg", "drop") +
+        load_ddl("last_agg_sfunc", "drop") +
+        load_ddl("proc_event_type_replace", "drop")
+    ),
 )
 
 

--- a/microcosm_eventsource/tests/ddl/test_migrations.py
+++ b/microcosm_eventsource/tests/ddl/test_migrations.py
@@ -1,0 +1,399 @@
+"""
+Persistence tests.
+
+"""
+from datetime import datetime
+from os import pardir
+from os.path import dirname, join
+from hamcrest import (
+    assert_that,
+    calling,
+    contains,
+    has_length,
+    has_properties,
+    raises,
+)
+from microcosm.api import create_object_graph
+from microcosm_postgres.context import SessionContext, transaction
+from sqlalchemy.exc import ProgrammingError, IntegrityError
+
+from microcosm_eventsource.tests.fixtures import (
+    Task,
+    TaskEvent,
+    TaskEventType,
+    Activity,
+    ActivityEvent,
+    ActivityEventType,
+)
+
+
+class TestMigrations:
+
+    def setup(self):
+        self.graph = create_object_graph(
+            "example",
+            root_path=join(dirname(__file__), pardir),
+            testing=True,
+        )
+        self.graph.use(
+            "task_store",
+            "task_event_store",
+            "activity_store",
+            "activity_event_store",
+        )
+        self.store = self.graph.task_event_store
+        self.activity_store = self.graph.activity_event_store
+
+        self.context = SessionContext(self.graph)
+        self.context.recreate_all()
+        self.context.open()
+
+        with transaction():
+            self.task = Task().create()
+            self.created_event = TaskEvent(
+                event_type=TaskEventType.CREATED,
+                task_id=self.task.id,
+            ).create()
+            self.scheduled_event = TaskEvent(
+                deadline=datetime.utcnow(),
+                event_type=TaskEventType.SCHEDULED,
+                parent_id=self.created_event.id,
+                state=[TaskEventType.CREATED, TaskEventType.SCHEDULED],
+                task_id=self.task.id,
+            ).create()
+            self.assigened_event = TaskEvent(
+                deadline=datetime.utcnow(),
+                event_type=TaskEventType.ASSIGNED,
+                parent_id=self.scheduled_event.id,
+                state=[TaskEventType.ASSIGNED, TaskEventType.CREATED, TaskEventType.SCHEDULED],
+                assignee="assignee",
+                task_id=self.task.id,
+            ).create()
+            self.started_event = TaskEvent(
+                event_type=TaskEventType.STARTED,
+                parent_id=self.assigened_event.id,
+                task_id=self.task.id,
+            ).create()
+            # flush sqlalchemy cache before sql operation
+            self.store.session.expire_all()
+
+    def teardown(self):
+        self.context.close()
+        self.graph.postgres.dispose()
+
+    def test_proc_event_type_delete(self):
+        """
+        Test that sql proc_event_type_delete function:
+        * delete events
+        * replaces parent_id
+        * updates states
+
+        """
+        with transaction():
+            self.store.session.execute("SELECT proc_event_type_delete('task_event', 'SCHEDULED', 'task_id');")
+
+        results = self.store.search()
+        assert_that(results, has_length(3))
+        assert_that(results, contains(
+            has_properties(
+                event_type=TaskEventType.STARTED,
+                state=[TaskEventType.STARTED],
+                id=self.started_event.id,
+                parent_id=self.assigened_event.id,
+            ),
+            has_properties(
+                event_type=TaskEventType.ASSIGNED,
+                state=[TaskEventType.ASSIGNED, TaskEventType.CREATED],
+                id=self.assigened_event.id,
+                parent_id=self.created_event.id,
+            ),
+            has_properties(
+                event_type=TaskEventType.CREATED,
+                state=[TaskEventType.CREATED],
+                id=self.created_event.id,
+                parent_id=None,
+            ),
+        ))
+
+    def test_proc_event_type_replace(self):
+        """
+        Test that proc_event_type_replace sql function:
+        * replace event_type
+        * replace event_types in state (and sort it)
+
+        """
+        with transaction():
+            self.store.session.execute("SELECT proc_event_type_replace('task_event', 'SCHEDULED', 'CANCELED');")
+
+        results = self.store.search()
+        assert_that(results, has_length(4))
+        assert_that(results, contains(
+            has_properties(
+                event_type=TaskEventType.STARTED,
+                state=[TaskEventType.STARTED],
+                id=self.started_event.id,
+                parent_id=self.assigened_event.id,
+            ),
+            has_properties(
+                event_type=TaskEventType.ASSIGNED,
+                state=[TaskEventType.ASSIGNED, TaskEventType.CANCELED, TaskEventType.CREATED],
+                id=self.assigened_event.id,
+                parent_id=self.scheduled_event.id,
+            ),
+            has_properties(
+                event_type=TaskEventType.CANCELED,
+                state=[TaskEventType.CANCELED, TaskEventType.CREATED],
+                id=self.scheduled_event.id,
+                parent_id=self.created_event.id,
+            ),
+            has_properties(
+                event_type=TaskEventType.CREATED,
+                state=[TaskEventType.CREATED],
+                id=self.created_event.id,
+                parent_id=None,
+            ),
+        ))
+
+    def test_delete_single_event(self):
+        """
+        Test that sql proc_events_delete function:
+        * delete events
+        * replaces parent_id
+
+        """
+        with transaction():
+            self.store.session.execute("""
+                CREATE TEMP TABLE events_to_remove AS (
+                    SELECT id FROM task_event WHERE event_type='SCHEDULED'
+                );
+                SELECT proc_events_delete('task_event', 'events_to_remove', 'task_id');
+            """)
+
+        results = self.store.search()
+        assert_that(results, has_length(3))
+        assert_that(results, contains(
+            has_properties(
+                event_type=TaskEventType.STARTED,
+                state=[TaskEventType.STARTED],
+                id=self.started_event.id,
+                parent_id=self.assigened_event.id,
+            ),
+            has_properties(
+                event_type=TaskEventType.ASSIGNED,
+                state=[TaskEventType.ASSIGNED, TaskEventType.CREATED, TaskEventType.SCHEDULED],
+                id=self.assigened_event.id,
+                parent_id=self.created_event.id,
+            ),
+            has_properties(
+                event_type=TaskEventType.CREATED,
+                state=[TaskEventType.CREATED],
+                id=self.created_event.id,
+                parent_id=None,
+            ),
+        ))
+
+    def test_edge_case_proc_event_type_replace_remove_duplicates(self):
+        """
+        Test that proc_event_type_replace sql function:
+        * replace event_type
+        * replace event_types in state and remove duplicates (and sort it)
+
+        """
+        with transaction():
+            self.store.session.execute("SELECT proc_event_type_replace('task_event', 'SCHEDULED', 'CREATED');")
+
+        results = self.store.search()
+        assert_that(results, has_length(4))
+        assert_that(results, contains(
+            has_properties(
+                event_type=TaskEventType.STARTED,
+                state=[TaskEventType.STARTED],
+                id=self.started_event.id,
+                parent_id=self.assigened_event.id,
+            ),
+            has_properties(
+                event_type=TaskEventType.ASSIGNED,
+                state=[TaskEventType.ASSIGNED, TaskEventType.CREATED],
+                id=self.assigened_event.id,
+                parent_id=self.scheduled_event.id,
+            ),
+            has_properties(
+                event_type=TaskEventType.CREATED,
+                state=[TaskEventType.CREATED],
+                id=self.scheduled_event.id,
+                parent_id=self.created_event.id,
+            ),
+            has_properties(
+                event_type=TaskEventType.CREATED,
+                state=[TaskEventType.CREATED],
+                id=self.created_event.id,
+                parent_id=None,
+            ),
+        ))
+
+    def test_edge_case_delete_number_of_events(self):
+        """
+        Test that sql proc_events_delete function:
+        * delete events
+        * replaces parent_id (even if the new parent is not directly refrenced by the deleted event)
+
+        """
+        with transaction():
+            self.store.session.execute("""
+                CREATE TEMP TABLE events_to_remove AS (
+                    SELECT id FROM task_event WHERE event_type='SCHEDULED' OR event_type='ASSIGNED'
+                );
+                SELECT proc_events_delete('task_event', 'events_to_remove', 'task_id');
+            """)
+
+        results = self.store.search()
+        assert_that(results, has_length(2))
+        assert_that(results, contains(
+            has_properties(
+                event_type=TaskEventType.STARTED,
+                state=[TaskEventType.STARTED],
+                id=self.started_event.id,
+                parent_id=self.created_event.id,
+            ),
+            has_properties(
+                event_type=TaskEventType.CREATED,
+                state=[TaskEventType.CREATED],
+                id=self.created_event.id,
+                parent_id=None,
+            ),
+        ))
+
+    def test_edge_case_delete_last_event(self):
+        """
+        Test that proc_event_type_replace sql function can delete last event of a model
+
+        """
+        with transaction():
+            self.store.session.execute("""
+                CREATE TEMP TABLE events_to_remove AS (
+                    SELECT id FROM task_event WHERE event_type='STARTED'
+                );
+                SELECT proc_events_delete('task_event', 'events_to_remove', 'task_id');
+            """)
+
+        results = self.store.search()
+        assert_that(results, has_length(3))
+        assert_that(results, contains(
+            has_properties(
+                event_type=TaskEventType.ASSIGNED,
+                state=[TaskEventType.ASSIGNED, TaskEventType.CREATED, TaskEventType.SCHEDULED],
+                id=self.assigened_event.id,
+                parent_id=self.scheduled_event.id,
+            ),
+            has_properties(
+                event_type=TaskEventType.SCHEDULED,
+                state=[TaskEventType.CREATED, TaskEventType.SCHEDULED],
+                id=self.scheduled_event.id,
+                parent_id=self.created_event.id,
+            ),
+            has_properties(
+                event_type=TaskEventType.CREATED,
+                state=[TaskEventType.CREATED],
+                id=self.created_event.id,
+                parent_id=None,
+            ),
+        ))
+
+    def test_edge_case_delete_first_event(self):
+        """
+        Can delete first events (But still have to follow "require_{}_parent_id" constraint)
+
+        """
+        with transaction():
+            self.activity_store.session.execute(
+                """
+                    CREATE TEMP TABLE events_to_remove AS (
+                        SELECT id FROM task_event WHERE event_type='CREATED'
+                    );
+                    SELECT proc_event_type_replace('task_event', 'SCHEDULED', 'CREATED');
+                    SELECT proc_events_delete('task_event', 'events_to_remove', 'task_id');
+                """
+            )
+            self.store.session.expire_all()
+        results = self.store.search()
+        assert_that(results, has_length(3))
+        assert_that(results, contains(
+            has_properties(
+                event_type=TaskEventType.STARTED,
+                state=[TaskEventType.STARTED],
+                id=self.started_event.id,
+                parent_id=self.assigened_event.id,
+            ),
+            has_properties(
+                event_type=TaskEventType.ASSIGNED,
+                state=[TaskEventType.ASSIGNED, TaskEventType.CREATED],
+                id=self.assigened_event.id,
+                parent_id=self.scheduled_event.id,
+            ),
+            has_properties(
+                event_type=TaskEventType.CREATED,
+                state=[TaskEventType.CREATED],
+                id=self.scheduled_event.id,
+                parent_id=None,
+            ),
+        ))
+
+    def test_edge_case_proc_events_delete_with_no_parent_id_constraint(self):
+        """
+        Some events dont have a parent_id_constraint (If model.__unique_parent__ is set to False)
+        In order to delete them, we have to call:
+            "proc_events_delete_with_no_parent_id_constraint" instead of "proc_events_delete".
+        We cannot call "proc_events_delete_with_no_parent_id_constraint" for events with constraint.
+
+        """
+        with transaction():
+            activity = Activity().create()
+            created_event = ActivityEvent(
+                event_type=ActivityEventType.CREATED,
+                activity_id=activity.id,
+            ).create()
+            ActivityEvent(
+                event_type=ActivityEventType.CANCELED,
+                parent_id=created_event.id,
+                activity_id=activity.id,
+            ).create()
+            self.activity_store.session.expire_all()
+
+        with transaction():
+            assert_that(calling(self.activity_store.session.execute).with_args(
+                """
+                    CREATE TEMP TABLE events_to_remove AS (
+                        SELECT id FROM activity_event WHERE event_type='CANCELED'
+                    );
+                    SELECT proc_events_delete('activity_event', 'events_to_remove', 'activity_id');
+                """
+                ), raises(ProgrammingError))
+
+        with transaction():
+            assert_that(calling(self.activity_store.session.execute).with_args(
+                """
+                    CREATE TEMP TABLE events_to_remove AS (
+                        SELECT id FROM task_event WHERE event_type='SCHEDULED'
+                    );
+                    SELECT proc_events_delete_with_no_parent_id_constraint('task_event', 'events_to_remove', 'task_id');
+                """
+                ), raises(IntegrityError))
+
+        with transaction():
+            self.activity_store.session.execute("""
+                CREATE TEMP TABLE events_to_remove AS (
+                    SELECT id FROM activity_event WHERE event_type='CANCELED'
+                );
+                SELECT proc_events_delete_with_no_parent_id_constraint('activity_event', 'events_to_remove', 'activity_id');
+            """)
+
+        results = self.activity_store.search()
+        assert_that(results, has_length(1))
+        assert_that(results, contains(
+            has_properties(
+                event_type=ActivityEventType.CREATED,
+                state=[ActivityEventType.CREATED],
+                id=created_event.id,
+                parent_id=None,
+            ),
+        ))

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import find_packages, setup
 
 project = "microcosm-eventsource"
-version = "1.9.0"
+version = "1.9.1"
 
 setup(
     name=project,


### PR DESCRIPTION
Create some sql functions to help alembic and ansible data migrations:
* `array_sort_unique` - returns sorted unique array (used for updating state)
* `replace_event_type` - replaces event type
* `delete_event_type` - deletes events type (updates parent_id)
* `delete_events` - deletes any events (passed as a temp table - more details about why temp table and not array later)
* `delete_events_with_no_parent_id_constraint` - same as `delete_events` - but used for the models with `mode.__unique_parent__=false`)

Why do we need it?
Writing migrations for microcosm-eventsource is not easy and can easily cause bugs - especially when involving adding or removing events.

Why sql function and not sql alchemy code / python script?
We want to support alembic and ansible data migrations.
I've saw (and wrote) some ansible data migrations that are sql only - and I want to support them.

What next?
If we want to continue with this style, we will add `insert_event` function and some `model_rollup` function.

Why `delete_events` input is a temp table and not an array?
While `delete_events` input is really an array, we're going to use it only for migrations - so we need to think about the migration use case:
1. 
The TEMP TABLE syntax:
```
CREATE TEMP TABLE events_to_remove AS (
    SELECT id FROM task_event WHERE event_type='SCHEDULED'
);
SELECT delete_events('task_event', 'events_to_remove', 'task_id');
```
is much more clear then the syntax that we would use with array:
```
SELECT delete_events(
    'task_event',
    array_agg(task_event.id),
    'task_id'
)
FROM task_event WHERE event_type='SCHEDULED';
```
There is no question about the beginning and end of the transaction - it's clear.

2.
Performance - in order to write `delete_events` - we have to use some joins. So we will have to create temp table anyway.
I'm also not sure uncertain what is the performance hit of passing huge arrays between functions. 