### PR TITLE
Rollup store: fix incorrect search limit result

### DIFF
--- a/microcosm_eventsource/tests/stores/test_rollup_limit.py
+++ b/microcosm_eventsource/tests/stores/test_rollup_limit.py
@@ -7,19 +7,12 @@ from os.path import dirname, join
 
 from hamcrest import (
     assert_that,
-    calling,
-    contains,
     contains_inanyorder,
-    equal_to,
     has_length,
     has_properties,
-    is_,
-    raises,
 )
 from microcosm.api import create_object_graph
 from microcosm_postgres.context import SessionContext, transaction
-from microcosm_postgres.errors import ModelNotFoundError
-from microcosm_postgres.identifiers import new_object_id
 
 from microcosm_eventsource.func import last
 from microcosm_eventsource.stores import RollUpStore
@@ -48,7 +41,7 @@ class SimpleObjectTestRollupStore(RollUpStore):
     def _filter(self, query, aggregate, event_type=None, **kwargs):
         if event_type:
             query = query.filter(
-                aggregate["event_type"] == str(event_type)
+                aggregate["event_type"] == str(event_type),
             )
 
         return super()._filter(query, aggregate, **kwargs)

--- a/microcosm_eventsource/tests/stores/test_rollup_limit.py
+++ b/microcosm_eventsource/tests/stores/test_rollup_limit.py
@@ -1,0 +1,173 @@
+"""
+Rolled up event limit tests.
+
+"""
+from os import pardir
+from os.path import dirname, join
+
+from hamcrest import (
+    assert_that,
+    calling,
+    contains,
+    contains_inanyorder,
+    equal_to,
+    has_length,
+    has_properties,
+    is_,
+    raises,
+)
+from microcosm.api import create_object_graph
+from microcosm_postgres.context import SessionContext, transaction
+from microcosm_postgres.errors import ModelNotFoundError
+from microcosm_postgres.identifiers import new_object_id
+
+from microcosm_eventsource.func import last
+from microcosm_eventsource.stores import RollUpStore
+from microcosm_eventsource.tests.fixtures import (
+    SimpleTestObject,
+    SimpleTestObjectEvent,
+    SimpleTestObjectEventType,
+)
+
+
+class SimpleObjectTestRollupStore(RollUpStore):
+
+    def __init__(self, graph):
+        super().__init__(
+            graph.simple_test_object_store,
+            graph.simple_test_object_event_store,
+        )
+
+    def _aggregate(self, **kwargs):
+        aggregate = super()._aggregate(**kwargs)
+        aggregate.update(
+            event_type=last.of(SimpleTestObjectEvent.event_type),
+        )
+        return aggregate
+
+    def _filter(self, query, aggregate, event_type=None, **kwargs):
+        if event_type:
+            query = query.filter(
+                aggregate["event_type"] == str(event_type)
+            )
+
+        return super()._filter(query, aggregate, **kwargs)
+
+
+class TestRolledUpEventStore:
+
+    def setup(self):
+        self.graph = create_object_graph(
+            "example",
+            root_path=join(dirname(__file__), pardir),
+            testing=True,
+        )
+        self.graph.use(
+            "simple_test_object_store",
+            "simple_test_object_event_store",
+        )
+        self.store = SimpleObjectTestRollupStore(self.graph)
+        self.event_store = self.graph.simple_test_object_event_store
+
+        self.context = SessionContext(self.graph)
+        self.context.recreate_all()
+        self.context.open()
+
+    def teardown(self):
+        self.context.close()
+        self.graph.postgres.dispose()
+
+    def create_events(self, until=None, **kwargs):
+        events = []
+        for event in self.iter_events(**kwargs):
+            if event.event_type == str(until):
+                return events
+            events.append(event)
+        return events
+
+    def iter_events(self, simple_test_object=None):
+        with transaction():
+            event = self.event_store.create(
+                SimpleTestObjectEvent(
+                    event_type=str(SimpleTestObjectEventType.CREATED),
+                    simple_test_object_id=simple_test_object.id,
+                ),
+            )
+
+        yield event
+
+        with transaction():
+            event = self.event_store.create(
+                SimpleTestObjectEvent(
+                    event_type=str(SimpleTestObjectEventType.READY),
+                    parent_id=event.id,
+                    simple_test_object_id=simple_test_object.id,
+                ),
+            )
+
+        yield event
+
+        with transaction():
+            event = self.event_store.create(
+                SimpleTestObjectEvent(
+                    event_type=str(SimpleTestObjectEventType.DONE),
+                    parent_id=event.id,
+                    simple_test_object_id=simple_test_object.id,
+                ),
+            )
+
+        yield event
+
+    def test_search_by_limit(self):
+        with transaction():
+            object1 = SimpleTestObject().create()
+            object2 = SimpleTestObject().create()
+            object3 = SimpleTestObject().create()
+            object4 = SimpleTestObject().create()
+
+            self.create_events(simple_test_object=object1, until=SimpleTestObjectEventType.CREATED)
+            self.create_events(simple_test_object=object2, until=SimpleTestObjectEventType.READY)
+            self.create_events(simple_test_object=object3, until=SimpleTestObjectEventType.DONE)
+            self.create_events(simple_test_object=object4, until=SimpleTestObjectEventType.DONE)
+
+            result = self.store.search()
+
+            assert_that(result, has_length(4))
+            assert_that(
+                result,
+                contains_inanyorder(
+                    has_properties(
+                        id=object1.id,
+                        _event_type=str(SimpleTestObjectEventType.CREATED),
+                    ),
+                    has_properties(
+                        id=object2.id,
+                        _event_type=str(SimpleTestObjectEventType.READY),
+                    ),
+                    has_properties(
+                        id=object3.id,
+                        _event_type=str(SimpleTestObjectEventType.DONE),
+                    ),
+                    has_properties(
+                        id=object4.id,
+                        _event_type=str(SimpleTestObjectEventType.DONE),
+                    ),
+                ),
+            )
+
+            result = self.store.search(event_type=str(SimpleTestObjectEventType.DONE))
+
+            assert_that(result, has_length(2))
+            assert_that(
+                result,
+                contains_inanyorder(
+                    has_properties(
+                        id=object3.id,
+                        _event_type=str(SimpleTestObjectEventType.DONE),
+                    ),
+                    has_properties(
+                        id=object4.id,
+                        _event_type=str(SimpleTestObjectEventType.DONE),
+                    ),
+                ),
+            )


### PR DESCRIPTION
## What is this?

the library's `RollupStore` object can return an incorrect search result when provided a `limit` argument. This is because of where the limit is applied with in the generate query. This PR fixes the search query to return a correct result based on a given limit.

## Details

This issue was first noticed in the new `probus` service. When searching for an extended approval session that matched a given event type along with a given limit, the corresponding roll store would return a list with less items than what was expected.

Digging into the rollup store revealed that when a `limit` was given, that argument would be passed down to the container store where the generated subquery would include `LIMIT`; however, the limit was not being applied to the final result. This means that the container subquery is returning a result that has a size that is AT MOST the given limit. The parent query then further reduce the result. Once the `LIMIT` clause would moved out of the container subquery and up into the main query, the correct result was being returned if an additional filter was supplied.

For example, I created a unit test that exercises this issue using a `SimpleTestObject` and a `SimpleTestObjectEvent`. The rollup store has a filter for the aggregate `event_type`. When compiling the the query WITHOUT the fix, this is what sqlalchemy produces (formatted for clarity):

``` sql
SELECT 
    anon_1.approval_session_event_id, anon_1.approval_session_event_created_at, 
    anon_1.approval_session_event_updated_at, anon_1.approval_session_event_comment, 
    anon_1.approval_session_event_user_id, anon_1.approval_session_event_resource_id, 
    anon_1.approval_session_event_resource_type, anon_1.approval_session_event_resource_version, 
    anon_1.approval_session_event_approval_session_id, anon_1.approval_session_event_event_type, 
    anon_1.approval_session_event_clock, anon_1.approval_session_event_parent_id, 
    anon_1.approval_session_event_state, anon_1.approval_session_event_version, 
    anon_1.approval_session_created_at, anon_1.approval_session_updated_at, 
    anon_1.approval_session_approval_strategy_type, anon_1.approval_session_company_id, 
    anon_1.approval_session_id, anon_1.approval_session_project_id, 
    anon_1.approval_session_workspace_id, 
    anon_1.anon_2, 
    anon_1.anon_3, 
    anon_1.anon_4, 
    anon_1.anon_5, 
    anon_1.anon_6
FROM (

    SELECT 
        approval_session_event.id AS approval_session_event_id, 
        approval_session_event.created_at AS approval_session_event_created_at, 
        approval_session_event.updated_at AS approval_session_event_updated_at, 
        approval_session_event.comment AS approval_session_event_comment, 
        approval_session_event.user_id AS approval_session_event_user_id, 
        approval_session_event.resource_id AS approval_session_event_resource_id, 
        approval_session_event.resource_type AS approval_session_event_resource_type, 
        approval_session_event.resource_version AS approval_session_event_resource_version, 
        approval_session_event.approval_session_id AS approval_session_event_approval_session_id, 
        approval_session_event.event_type AS approval_session_event_event_type, 
        approval_session_event.clock AS approval_session_event_clock, 
        approval_session_event.parent_id AS approval_session_event_parent_id, 
        approval_session_event.state AS approval_session_event_state, 
        approval_session_event.version AS approval_session_event_version, 
        approval_session.created_at AS approval_session_created_at, 
        approval_session.updated_at AS approval_session_updated_at, 
        approval_session.approval_strategy_type AS approval_session_approval_strategy_type, 
        approval_session.company_id AS approval_session_company_id, 
        approval_session.id AS approval_session_id, 
        approval_session.project_id AS approval_session_project_id, 
        approval_session.workspace_id AS approval_session_workspace_id, 
        rank() 
            OVER (PARTITION BY approval_session_event.approval_session_id ORDER BY approval_session_event.clock DESC) AS anon_2, 
        last_agg(approval_session_event.event_type) 
            OVER (PARTITION BY approval_session_event.approval_session_id ORDER BY approval_session_event.clock ASC) AS anon_3, 
        last_agg(approval_session_event.resource_id) 
            OVER (PARTITION BY approval_session_event.approval_session_id ORDER BY approval_session_event.clock ASC) AS anon_4, 
        last_agg(approval_session_event.resource_type) 
            OVER (PARTITION BY approval_session_event.approval_session_id ORDER BY approval_session_event.clock ASC) AS anon_5, 
        last_agg(approval_session_event.resource_version) 
            OVER (PARTITION BY approval_session_event.approval_session_id ORDER BY approval_session_event.clock ASC) AS anon_6
    FROM approval_session_event 
    JOIN (
        SELECT 
            approval_session.created_at AS created_at, 
            approval_session.updated_at AS updated_at, 
            approval_session.approval_strategy_type AS 
            approval_strategy_type, approval_session.company_id AS company_id, 
            approval_session.id AS id, approval_session.project_id AS project_id, 
            approval_session.workspace_id AS workspace_id
        FROM approval_session
        LIMIT %(param_1)s OFFSET %(param_2)s
     ) AS approval_session ON approval_session.id = approval_session_event.approval_session_id

 ) AS anon_1
WHERE anon_1.anon_2 = %(param_3) AND anon_1.anon_3 = %(param_4)s
```

Note where the `LIMIT` and `OFFSET` clauses are applied: Within the container subquery.

With the fix, this is what sqlalchemy produces (formatted for clarity):

``` sql
SELECT 
    anon_1.simple_test_object_event_id, 
    anon_1.simple_test_object_event_created_at, 
    anon_1.simple_test_object_event_updated_at, 
    anon_1.simple_test_object_event_simple_test_object_id, 
    anon_1.simple_test_object_event_event_type, 
    anon_1.simple_test_object_event_clock, 
    anon_1.simple_test_object_event_parent_id, 
    anon_1.simple_test_object_event_state, 
    anon_1.simple_test_object_event_version, 
    anon_1.simple_test_object_created_at, 
    anon_1.simple_test_object_updated_at, 
    anon_1.simple_test_object_id, 
    anon_1.simple_test_object_project_id, 
    anon_1.anon_2, 
    anon_1.anon_3, 
FROM (

    SELECT 
        simple_test_object_event.id AS simple_test_object_event_id, 
        simple_test_object_event.created_at AS simple_test_object_event_created_at, 
        simple_test_object_event.updated_at AS simple_test_object_event_updated_at, 
        simple_test_object_event.simple_test_object_id AS simple_test_object_event_simple_test_object_id, 
        simple_test_object_event.event_type AS simple_test_object_event_event_type, 
        simple_test_object_event.clock AS simple_test_object_event_clock, 
        simple_test_object_event.parent_id AS simple_test_object_event_parent_id, 
        simple_test_object_event.state AS simple_test_object_event_state, 
        simple_test_object_event.version AS simple_test_object_event_version, 
        simple_test_object.created_at AS simple_test_object_created_at, 
        simple_test_object.updated_at AS simple_test_object_updated_at, 
        simple_test_object.id AS simple_test_object_id, 
        rank() 
            OVER (PARTITION BY simple_test_object_event.simple_test_object_id ORDER BY simple_test_object_event.clock DESC) AS anon_2, 
        last_agg(simple_test_object_event.event_type) 
            OVER (PARTITION BY simple_test_object_event.simple_test_object_id ORDER BY simple_test_object_event.clock ASC) AS anon_3,
    FROM simple_test_object_event 
    JOIN (
        SELECT 
            simple_test_object.created_at AS created_at, 
            simple_test_object.updated_at AS updated_at, 
            simple_test_object.id AS id, simple_test_object.project_id AS project_id, 
        FROM simple_test_object
     ) AS simple_test_object ON simple_test_object.id = simple_test_object_event.simple_test_object_id
 ) AS anon_1
WHERE anon_1.anon_2 = %(param_1) AND anon_1.anon_3 = %(param_2)s
LIMIT %(param_3)s OFFSET %(param_4)s
```