### PR TITLE
Support deferred-batch

### DIFF
--- a/microcosm_eventsource/routes.py
+++ b/microcosm_eventsource/routes.py
@@ -6,16 +6,25 @@ from microcosm_flask.conventions.base import EndpointDefinition
 from microcosm_flask.conventions.crud import configure_crud
 from microcosm_flask.operations import Operation
 from microcosm_postgres.context import transactional
+from microcosm_pubsub.producer import deferred_batch
 
 
-def configure_event_crud(graph,
-                         controller,
-                         event_schema,
-                         new_event_schema,
-                         search_event_schema):
+def configure_event_crud(
+    graph,
+    controller,
+    event_schema,
+    new_event_schema,
+    search_event_schema,
+    use_deferred_batch=False,
+):
+    if use_deferred_batch:
+        create_func = transactional(deferred_batch(controller)(controller.create))
+    else:
+        create_func = transactional(controller.create)
+
     mappings = {
         Operation.Create: EndpointDefinition(
-            func=transactional(controller.create),
+            func=create_func,
             request_schema=new_event_schema,
             response_schema=event_schema,
         ),

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         "microcosm-flask>=1.0.1",
         "microcosm-logging>=1.0.0",
         "microcosm-postgres>=1.0.0",
-        "microcosm-pubsub>=1.0.0",
+        "microcosm-pubsub>=1.11.2",
     ],
     setup_requires=[
         "nose>=1.3.6",


### PR DESCRIPTION
Sometimes, creating one event can lead to more events.
In those cases - we probably want to use `deferred_batch` to publish all of them as a batch - to speed up the transaction.

`configure_event_crud` should support this option 