### PR TITLE
Added the option to sort an event by clock in an ascending order

### DIFF
--- a/microcosm_eventsource/stores/event.py
+++ b/microcosm_eventsource/stores/event.py
@@ -105,15 +105,20 @@ class EventStore(Store):
 
         return super(EventStore, self)._filter(query, **kwargs)
 
-    def _order_by(self, query, sort_by_clock=False, **kwargs):
+    def _order_by(self, query, sort_by_clock=False, sort_clock_in_ascending_order=False, **kwargs):
         """
         Order events by logical clock.
 
         """
         if sort_by_clock:
-            return query.order_by(
-                self.model_class.clock.desc(),
-            )
+            if sort_clock_in_ascending_order:
+                return query.order_by(
+                    self.model_class.clock.asc(),
+                )
+            else:
+                return query.order_by(
+                    self.model_class.clock.desc(),
+                )
         return query.order_by(
             self.model_class.container_id.desc(),
             self.model_class.clock.desc(),


### PR DESCRIPTION
Why?
Usually we want to sort events from newest-oldest (Descending), but should also give the option to sort from oldest-newest (Ascending)