### PR TITLE
Add new ddl for creating events.

### DIFF
--- a/microcosm_eventsource/ddl/proc_events_create.create.ddl
+++ b/microcosm_eventsource/ddl/proc_events_create.create.ddl
@@ -1,0 +1,99 @@
+/*
+ * proc_events_create(table_name, events_to_create_table_name, columns)
+ *
+ * Should be only used by data migrations scripts.
+ * Creates events from table table_name - a valid microcosm-event-source event table.
+ * Pass the events to create as row from table events_to_create_table_name.
+ * Must pass model_id_row_name - the row name that links to the parent model
+ * Must pass the listen of expected columns to be inserted into the target event table.
+ * (Example: for company_event table, the model_id_row_name should be company_id)
+ *
+ * Example:
+ *    CREATE TEMP TABLE events_to_create AS (\n"
+ *           SELECT\n"
+ *              '{reassigned_event_id}'::uuid as id,
+ *              extract(epoch from now()) as created_at,
+ *              extract(epoch from now()) as updated_at,
+ *              assignee,
+ *              NULL::timestamp without time zone as deadline,
+ *              task_id,
+ *              'REASSIGNED' as event_type,
+ *              id as parent_id,
+ *              state,
+ *              1 as version
+ *           FROM task_event WHERE event_type='ASSIGNED'
+ *        );
+ * FROM task_event WHERE event_type='SCHEDULED');
+ * SELECT proc_events_create('task_event', 'events_to_create', 'task_id');
+ *
+ * Details:
+ * - Won't update the state
+ * - Creates the relevant events
+ * - Updates the parent_id of events affected by inserted rows
+ * - Cannot be used if model.__unique_parent__ is set to False (missing table_names_parent_id_key constraint),
+ *   If thats the case - use proc_events_delete_with_no_parent_id_constraint function instead.
+ */
+CREATE OR REPLACE FUNCTION proc_events_create(
+    table_name regclass,
+    events_to_create_table_name regclass,
+    columns character varying(255)
+) RETURNS void AS
+$func$
+BEGIN
+    EXECUTE format(
+        '
+            ALTER TABLE %%1$s DROP CONSTRAINT %%1$s_parent_id_key;
+            SELECT proc_events_create_with_no_parent_id_constraint(''%%1$s'', ''%%2$s'', ''%%3$s'');
+            ALTER TABLE %%1$s ADD CONSTRAINT %%1$s_parent_id_key UNIQUE (parent_id);
+        ',
+        table_name,
+        events_to_create_table_name,
+        columns
+    );
+END
+$func$  LANGUAGE plpgsql;
+
+
+/*
+ * proc_events_create_with_no_parent_id_constraint(table_name, events_to_create_table_name, columns)
+ *
+ * Should be only used by data migrations scripts.
+ * Same as proc_events_delete function but for use if model.__unique_parent__ is set to False
+ * (missing table_names_parent_id_key constraint),
+ */
+CREATE OR REPLACE FUNCTION proc_events_create_with_no_parent_id_constraint(
+    table_name regclass,
+    events_to_create_table_name regclass,
+    columns character varying(255)
+) RETURNS void AS
+$func$
+BEGIN
+    EXECUTE format(
+        '
+            -- Temporary drop the constraint, bring it back before the end of the transaction.
+             ALTER TABLE %%1$s DROP CONSTRAINT %%1$s_parent_id_fkey;
+
+            -- Create new events
+            INSERT INTO %%1$s %%3$s (SELECT * FROM %%2$s);
+
+            -- Updates parent_id of events if by creating a new event, gives an existing event a new parent.
+            WITH new_child_events_parents AS (
+                SELECT child_event.id AS child_event_id, parent_event.id AS new_parent_id             
+                FROM %%1$s AS child_event
+                JOIN %%2$s AS parent_event 
+                ON child_event.parent_id = parent_event.parent_id
+                where parent_event.id != child_event.id                            
+            )
+            UPDATE %%1$s
+            SET parent_id = new_child_events_parents.new_parent_id                                    
+            FROM new_child_events_parents
+            WHERE %%1$s.id = new_child_events_parents.child_event_id;  
+
+            ALTER TABLE %%1$s ADD CONSTRAINT %%1$s_parent_id_fkey FOREIGN KEY (parent_id) REFERENCES %%1$s(id);
+        ',
+        table_name,
+        events_to_create_table_name,
+        columns
+    );
+END
+$func$  LANGUAGE plpgsql;

--- a/microcosm_eventsource/ddl/proc_events_create.create.ddl
+++ b/microcosm_eventsource/ddl/proc_events_create.create.ddl
@@ -6,6 +6,7 @@
  * Pass the events to create as row from table events_to_create_table_name.
  * Must pass model_id_row_name - the row name that links to the parent model
  * Must pass the listen of expected columns to be inserted into the target event table.
+ * Note: Events to create must not be initial events.
  * (Example: for company_event table, the model_id_row_name should be company_id)
  *
  * Example:

--- a/microcosm_eventsource/ddl/proc_events_create.drop.ddl
+++ b/microcosm_eventsource/ddl/proc_events_create.drop.ddl
@@ -1,0 +1,2 @@
+DROP FUNCTION IF EXISTS proc_events_create(regclass, regclass, character varying(255));
+DROP FUNCTION IF EXISTS proc_events_create_with_no_parent_id_constraint(regclass, character varying(255), character varying(255));

--- a/microcosm_eventsource/func.py
+++ b/microcosm_eventsource/func.py
@@ -21,6 +21,7 @@ listen(
     "after_create",
     DDL(
         load_ddl("array_sort_unique", "create") +
+        load_ddl("proc_events_create", "create") +
         load_ddl("proc_events_delete", "create") +
         load_ddl("proc_event_type_delete", "create") +
         load_ddl("last_agg_sfunc", "create") +
@@ -33,6 +34,7 @@ listen(
     "after_drop",
     DDL(
         load_ddl("array_sort_unique", "drop") +
+        load_ddl("proc_events_create", "drop") +
         load_ddl("proc_events_delete", "drop") +
         load_ddl("proc_event_type_delete", "drop") +
         load_ddl("last_agg", "drop") +

--- a/microcosm_eventsource/tests/ddl/test_migrations.py
+++ b/microcosm_eventsource/tests/ddl/test_migrations.py
@@ -15,6 +15,7 @@ from hamcrest import (
 )
 from microcosm.api import create_object_graph
 from microcosm_postgres.context import SessionContext, transaction
+from microcosm_postgres.identifiers import new_object_id
 from sqlalchemy.exc import ProgrammingError, IntegrityError
 
 from microcosm_eventsource.tests.fixtures import (
@@ -61,7 +62,7 @@ class TestMigrations:
                 state=[TaskEventType.CREATED, TaskEventType.SCHEDULED],
                 task_id=self.task.id,
             ).create()
-            self.assigened_event = TaskEvent(
+            self.assigned_event = TaskEvent(
                 deadline=datetime.utcnow(),
                 event_type=TaskEventType.ASSIGNED,
                 parent_id=self.scheduled_event.id,
@@ -71,7 +72,7 @@ class TestMigrations:
             ).create()
             self.started_event = TaskEvent(
                 event_type=TaskEventType.STARTED,
-                parent_id=self.assigened_event.id,
+                parent_id=self.assigned_event.id,
                 task_id=self.task.id,
             ).create()
             # flush sqlalchemy cache before sql operation
@@ -99,12 +100,12 @@ class TestMigrations:
                 event_type=TaskEventType.STARTED,
                 state=[TaskEventType.STARTED],
                 id=self.started_event.id,
-                parent_id=self.assigened_event.id,
+                parent_id=self.assigned_event.id,
             ),
             has_properties(
                 event_type=TaskEventType.ASSIGNED,
                 state=[TaskEventType.ASSIGNED, TaskEventType.CREATED],
-                id=self.assigened_event.id,
+                id=self.assigned_event.id,
                 parent_id=self.created_event.id,
             ),
             has_properties(
@@ -132,12 +133,12 @@ class TestMigrations:
                 event_type=TaskEventType.STARTED,
                 state=[TaskEventType.STARTED],
                 id=self.started_event.id,
-                parent_id=self.assigened_event.id,
+                parent_id=self.assigned_event.id,
             ),
             has_properties(
                 event_type=TaskEventType.ASSIGNED,
                 state=[TaskEventType.ASSIGNED, TaskEventType.CANCELED, TaskEventType.CREATED],
-                id=self.assigened_event.id,
+                id=self.assigned_event.id,
                 parent_id=self.scheduled_event.id,
             ),
             has_properties(
@@ -176,12 +177,12 @@ class TestMigrations:
                 event_type=TaskEventType.STARTED,
                 state=[TaskEventType.STARTED],
                 id=self.started_event.id,
-                parent_id=self.assigened_event.id,
+                parent_id=self.assigned_event.id,
             ),
             has_properties(
                 event_type=TaskEventType.ASSIGNED,
                 state=[TaskEventType.ASSIGNED, TaskEventType.CREATED, TaskEventType.SCHEDULED],
-                id=self.assigened_event.id,
+                id=self.assigned_event.id,
                 parent_id=self.created_event.id,
             ),
             has_properties(
@@ -209,12 +210,12 @@ class TestMigrations:
                 event_type=TaskEventType.STARTED,
                 state=[TaskEventType.STARTED],
                 id=self.started_event.id,
-                parent_id=self.assigened_event.id,
+                parent_id=self.assigned_event.id,
             ),
             has_properties(
                 event_type=TaskEventType.ASSIGNED,
                 state=[TaskEventType.ASSIGNED, TaskEventType.CREATED],
-                id=self.assigened_event.id,
+                id=self.assigned_event.id,
                 parent_id=self.scheduled_event.id,
             ),
             has_properties(
@@ -282,7 +283,7 @@ class TestMigrations:
             has_properties(
                 event_type=TaskEventType.ASSIGNED,
                 state=[TaskEventType.ASSIGNED, TaskEventType.CREATED, TaskEventType.SCHEDULED],
-                id=self.assigened_event.id,
+                id=self.assigned_event.id,
                 parent_id=self.scheduled_event.id,
             ),
             has_properties(
@@ -322,12 +323,12 @@ class TestMigrations:
                 event_type=TaskEventType.STARTED,
                 state=[TaskEventType.STARTED],
                 id=self.started_event.id,
-                parent_id=self.assigened_event.id,
+                parent_id=self.assigned_event.id,
             ),
             has_properties(
                 event_type=TaskEventType.ASSIGNED,
                 state=[TaskEventType.ASSIGNED, TaskEventType.CREATED],
-                id=self.assigened_event.id,
+                id=self.assigned_event.id,
                 parent_id=self.scheduled_event.id,
             ),
             has_properties(
@@ -384,7 +385,11 @@ class TestMigrations:
                 CREATE TEMP TABLE events_to_remove AS (
                     SELECT id FROM activity_event WHERE event_type='CANCELED'
                 );
-                SELECT proc_events_delete_with_no_parent_id_constraint('activity_event', 'events_to_remove', 'activity_id');
+                SELECT proc_events_delete_with_no_parent_id_constraint(
+                    'activity_event',
+                    'events_to_remove',
+                    'activity_id'
+                );
             """)
 
         results = self.activity_store.search()
@@ -394,6 +399,89 @@ class TestMigrations:
                 event_type=ActivityEventType.CREATED,
                 state=[ActivityEventType.CREATED],
                 id=created_event.id,
+                parent_id=None,
+            ),
+        ))
+
+    def test_proc_events_create(self):
+        """
+        Let's say we want to insert a revised event before the started event.
+
+        """
+        reassigned_event_id = new_object_id()
+
+        events_to_create_string = (
+            f"CREATE TEMP TABLE events_to_create AS (\n"
+            f"       SELECT\n"
+            f"          '{reassigned_event_id}'::uuid as id,\n"
+            f"          extract(epoch from now()) as created_at,\n"
+            f"          extract(epoch from now()) as updated_at,\n"
+            f"          assignee,\n"
+            f"          NULL::timestamp without time zone as deadline,\n"
+            f"          task_id,\n"
+            f"          'REASSIGNED' as event_type,\n"
+            f"          id as parent_id,\n"
+            f"          state,\n"
+            f"          1 as version\n"
+            f"       FROM task_event WHERE event_type='ASSIGNED'\n"
+            f"    );"
+        )
+
+        self.activity_store.session.execute(events_to_create_string)
+
+        self.activity_store.session.execute("""
+            SELECT proc_events_create(
+                'task_event',
+                'events_to_create',
+                '(
+                    id,
+                    created_at,
+                    updated_at,
+                    assignee,
+                    deadline,
+                    task_id,
+                    event_type,
+                    parent_id,
+                    state,
+                    version
+                )'
+            );
+        """)
+        results = self.store.search()
+        assert_that(results, has_length(5))
+
+        # NB: The events appear out of order because they are sorted by clock,
+        # but the parent id chain is correct. In particular the parent of the
+        # STARTED event has been changed by the migration
+        assert_that(results, contains(
+            has_properties(
+                event_type=TaskEventType.REASSIGNED,
+                state=[TaskEventType.ASSIGNED, TaskEventType.CREATED, TaskEventType.SCHEDULED],
+                parent_id=self.assigned_event.id,
+                id=reassigned_event_id,
+            ),
+            has_properties(
+                event_type=TaskEventType.STARTED,
+                state=[TaskEventType.STARTED],
+                id=self.started_event.id,
+                parent_id=reassigned_event_id,
+            ),
+            has_properties(
+                event_type=TaskEventType.ASSIGNED,
+                state=[TaskEventType.ASSIGNED, TaskEventType.CREATED, TaskEventType.SCHEDULED],
+                id=self.assigned_event.id,
+                parent_id=self.scheduled_event.id,
+            ),
+            has_properties(
+                event_type=TaskEventType.SCHEDULED,
+                state=[TaskEventType.CREATED, TaskEventType.SCHEDULED],
+                id=self.scheduled_event.id,
+                parent_id=self.created_event.id,
+            ),
+            has_properties(
+                event_type=TaskEventType.CREATED,
+                state=[TaskEventType.CREATED],
+                id=self.created_event.id,
                 parent_id=None,
             ),
         ))


### PR DESCRIPTION
Why? So far we have been missing an operation to create events in a
microcosm eventsource table. It turns out this isn't so complicated to
add!

Builds off of: https://github.com/globality-corp/microcosm-eventsource/pull/37 which has been a great starting point.