### PR TITLE
added new method in event sourcing, which makes sure parent container…

### DIFF
--- a/microcosm_eventsource/errors.py
+++ b/microcosm_eventsource/errors.py
@@ -4,6 +4,12 @@ State machine errors.
 """
 
 
+class ContainerLockNotAvailableRetry(Exception):
+    @property
+    def status_code(self):
+        return 423
+
+
 class ConcurrentStateConflictError(Exception):
     @property
     def status_code(self):

--- a/microcosm_eventsource/stores/event.py
+++ b/microcosm_eventsource/stores/event.py
@@ -6,9 +6,12 @@ import psycopg2
 from microcosm_postgres.models import Model
 from microcosm_postgres.store import Store
 from sqlalchemy.dialects.postgresql import insert
-
-from microcosm_eventsource.errors import ConcurrentStateConflictError, ContainerLockNotAvailableRetry
 from sqlalchemy.exc import OperationalError
+
+from microcosm_eventsource.errors import (
+    ConcurrentStateConflictError,
+    ContainerLockNotAvailableRetry,
+)
 
 
 class EventStore(Store):

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         "microcosm-logging>=1.5.0",
         "microcosm-postgres>=1.14.0",
         "microcosm-pubsub>=2.4.1",
+        "python-dateutil<2.8.1",
     ],
     setup_requires=[
         "nose>=1.3.6",


### PR DESCRIPTION
added new method in event sourcing, which makes sure parent container is available for processing, to not cause locking between two different webservers processing event on same parent container object.
In case of LockNotAvailable error, service would raise an error with 423 status code. https://httpstatuses.com/423

Following this, https://github.com/globality-corp/corto/blob/2cb5b504c3f377ffde918f1d89a023aa2036984f/corto/factories/channel_event_factory.py#L30 call should be replaced with "retrieve_most_recent_with_update_lock" method.