### PR TITLE
Compatability with SQLAlchemy 1.4.x ,  Remove python-dateutil version pin

### DIFF
--- a/microcosm_eventsource/stores/rollup.py
+++ b/microcosm_eventsource/stores/rollup.py
@@ -16,7 +16,6 @@ def with_labels(dct):
     """
     Add labels to all column clauses in the given dictionary of aggregate query clauses.
 
-
     This is meant to be used with the output of `RollUpStore._aggregate` below, and serves
     as a workaround for an issue in SQLAlchemy currently affecting 1.4.x.
     We should removed this once the issue is fixed in the library.

--- a/microcosm_eventsource/stores/rollup.py
+++ b/microcosm_eventsource/stores/rollup.py
@@ -18,7 +18,7 @@ def with_labels(dct):
 
     This is meant to be used with the output of `RollUpStore._aggregate` below, and serves
     as a workaround for an issue in SQLAlchemy currently affecting 1.4.x.
-    We should remove this once the issue is fixed in the library.
+    We should remove this once the issue is fixed in the library (GLOB-53044).
 
     See:
         https://github.com/sqlalchemy/sqlalchemy/issues/6256#issuecomment-819060298

--- a/microcosm_eventsource/stores/rollup.py
+++ b/microcosm_eventsource/stores/rollup.py
@@ -12,6 +12,25 @@ from microcosm_eventsource.func import ranked
 from microcosm_eventsource.models.rollup import RollUp
 
 
+def with_labels(dct):
+    """
+    Add labels to all column clauses in the given dictionary of aggregate query clauses.
+
+
+    This is meant to be used with the output of `RollUpStore._aggregate` below, and serves
+    as a workaround for an issue in SQLAlchemy currently affecting 1.4.x.
+    We should removed this once the issue is fixed in the library.
+
+    See:
+        https://github.com/sqlalchemy/sqlalchemy/issues/6256#issuecomment-819060298
+
+    """
+    return {
+        key: value.label(key)
+        for key, value in dct.items()
+    }
+
+
 class RollUpStore:
 
     def __init__(self, container_store, event_store, rollup=RollUp):
@@ -49,7 +68,7 @@ class RollUpStore:
 
         """
         container = self._retrieve_container(identifier)
-        aggregate = self._aggregate()
+        aggregate = with_labels(self._aggregate())
 
         try:
             return self._to_model(
@@ -98,7 +117,7 @@ class RollUpStore:
         Implement a rolled-up search of containers by their most recent event.
 
         """
-        aggregate = self._aggregate(**kwargs)
+        aggregate = with_labels(self._aggregate(**kwargs))
         return [
             self._to_model(aggregate, *row)
             for row in self._search_query(aggregate, **kwargs).all()
@@ -147,7 +166,8 @@ class RollUpStore:
         # results returned from this method does not match the limit provided
 
         container = self._search_container(**kwargs)
-        aggregate = aggregate or self._aggregate(**kwargs)
+        aggregate = with_labels(aggregate or self._aggregate(**kwargs))
+
         query = self._filter(
             self._rollup_query(
                 container,

--- a/microcosm_eventsource/stores/rollup.py
+++ b/microcosm_eventsource/stores/rollup.py
@@ -18,7 +18,7 @@ def with_labels(dct):
 
     This is meant to be used with the output of `RollUpStore._aggregate` below, and serves
     as a workaround for an issue in SQLAlchemy currently affecting 1.4.x.
-    We should removed this once the issue is fixed in the library.
+    We should remove this once the issue is fixed in the library.
 
     See:
         https://github.com/sqlalchemy/sqlalchemy/issues/6256#issuecomment-819060298

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ setup(
         "microcosm-logging>=1.5.0",
         "microcosm-postgres>=1.19.0",
         "microcosm-pubsub>=2.23.0",
-        "python-dateutil<2.8.1",
     ],
     setup_requires=[
         "nose>=1.3.6",


### PR DESCRIPTION
* Unpin `python-dateutil` and remove the dependency altogether - Doesn't seem to be required anymore, and since this library is a dependency for many of our services, it is blocking us from removing this pin in many other places as well.
* Fixes a current regression that affects `sqlalchemy` 1.4.x and up to do with usage of `compiles()` and `from_self()`. See more information [here](https://github.com/sqlalchemy/sqlalchemy/issues/6256)