### PR TITLE
Remove shim for sqlalchemy bug that is fixed in latest

### DIFF
--- a/microcosm_eventsource/stores/rollup.py
+++ b/microcosm_eventsource/stores/rollup.py
@@ -12,24 +12,6 @@ from microcosm_eventsource.func import ranked
 from microcosm_eventsource.models.rollup import RollUp
 
 
-def with_labels(dct):
-    """
-    Add labels to all column clauses in the given dictionary of aggregate query clauses.
-
-    This is meant to be used with the output of `RollUpStore._aggregate` below, and serves
-    as a workaround for an issue in SQLAlchemy currently affecting 1.4.x.
-    We should remove this once the issue is fixed in the library (GLOB-53044).
-
-    See:
-        https://github.com/sqlalchemy/sqlalchemy/issues/6256#issuecomment-819060298
-
-    """
-    return {
-        key: value.label(key)
-        for key, value in dct.items()
-    }
-
-
 class RollUpStore:
 
     def __init__(self, container_store, event_store, rollup=RollUp):
@@ -67,7 +49,7 @@ class RollUpStore:
 
         """
         container = self._retrieve_container(identifier)
-        aggregate = with_labels(self._aggregate())
+        aggregate = self._aggregate()
 
         try:
             return self._to_model(
@@ -116,7 +98,7 @@ class RollUpStore:
         Implement a rolled-up search of containers by their most recent event.
 
         """
-        aggregate = with_labels(self._aggregate(**kwargs))
+        aggregate = self._aggregate(**kwargs)
         return [
             self._to_model(aggregate, *row)
             for row in self._search_query(aggregate, **kwargs).all()
@@ -165,7 +147,7 @@ class RollUpStore:
         # results returned from this method does not match the limit provided
 
         container = self._search_container(**kwargs)
-        aggregate = with_labels(aggregate or self._aggregate(**kwargs))
+        aggregate = aggregate or self._aggregate(**kwargs)
 
         query = self._filter(
             self._rollup_query(

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         "microcosm>=2.12.0",
         "microcosm-flask>=2.8.0",
         "microcosm-logging>=1.5.0",
-        "microcosm-postgres>=1.19.0",
+        "microcosm-postgres>=2.2.0",
         "microcosm-pubsub>=2.23.0",
     ],
     setup_requires=[


### PR DESCRIPTION
- Require latest microcosm-postgres for pulling latest sqlalchemy (1.4.10 and up) where the bug affecting this repo was addressed
- Remove the shim we had to put in place in meanwhile